### PR TITLE
Baseline GFE Fixes For Booting FreeBSD

### DIFF
--- a/hw/src_AWS_P2/Makefile
+++ b/hw/src_AWS_P2/Makefile
@@ -47,7 +47,12 @@ CONNECTALFLAGS += -D AWSF1_DMA_PCIS
 
 ARCH ?= RV64ACDFIMSU
 
-CONNECTALFLAGS += --bscflags="-keep-fires -no-warn-action-shadowing -show-range-conflict"
+BSCFLAGS += \
+	-keep-fires -aggressive-conditions -no-warn-action-shadowing -no-show-timestamps \
+	-suppress-warnings G0020    \
+	+RTS -K128M -RTS  -show-range-conflict
+
+CONNECTALFLAGS += --bscflags="$(BSCFLAGS)"
 CONNECTALFLAGS += -DRV64
 CONNECTALFLAGS += -DSV39
 CONNECTALFLAGS += -DISA_PRIV_M  -DISA_PRIV_S  -DISA_PRIV_U

--- a/hw/src_AWS_P2/P2_Core.bsv
+++ b/hw/src_AWS_P2/P2_Core.bsv
@@ -1,0 +1,316 @@
+// Copyright (c) 2018-2019 Bluespec, Inc. All Rights Reserved.
+
+package P2_Core;
+
+// ================================================================
+// This package defines the interface and implementation of the 'P2 Core'
+// for the DARPA SSITH project.
+// This P2 core contains:
+//    - Flute CPU, including
+//        - Near_Mem (ICache and DCache)
+//        - Near_Mem_IO (Timer, Software-interrupt, and other mem-mapped-locations)
+//        - External interrupt request lines
+//        - 2 x AXI4 Master interfaces (from DM and ICache, and from DCache)
+//    - RISC-V Debug Module (DM)
+//    - JTAG TAP interface for DM
+//    - Optional Tandem Verification trace stream output interface
+
+// ================================================================
+// BSV library imports
+
+import Vector        :: *;
+import FIFO          :: *;
+import GetPut        :: *;
+import ClientServer  :: *;
+import Connectable   :: *;
+import Bus           :: *;
+
+// ----------------
+// BSV additional libs
+
+import GetPut_Aux :: *;
+import Semi_FIFOF :: *;
+
+// ================================================================
+// Project imports
+
+import SoC_Map  :: *;
+
+// The basic core
+import Core_IFC :: *;
+import Core     :: *;
+
+// External interrupt request interface
+import PLIC :: *;    // for PLIC_Source_IFC type which is exposed at P2_Core interface
+
+// Main Fabric
+import AXI4_Types   :: *;
+import AXI4_Fabric  :: *;
+import Fabric_Defs  :: *;
+
+`ifdef INCLUDE_TANDEM_VERIF
+import TV_Info :: *;
+import AXI4_Stream ::*;
+`endif
+
+`ifdef INCLUDE_GDB_CONTROL
+import Debug_Module :: *;
+`ifdef JTAG_TAP
+import JtagTap      :: *;
+import Giraffe_IFC  :: *;
+`endif
+`endif
+
+// ================================================================
+// The P2_Core interface
+
+interface P2_Core_IFC;
+
+   // ----------------------------------------------------------------
+   // Core CPU interfaces
+
+   // CPU IMem to Fabric master interface
+   interface AXI4_Master_IFC #(Wd_Id, Wd_Addr, Wd_Data, Wd_User) master0;
+
+   // CPU DMem (incl. I/O) to Fabric master interface
+   interface AXI4_Master_IFC #(Wd_Id, Wd_Addr, Wd_Data, Wd_User) master1;
+
+   // External interrupt sources
+   (* always_ready, always_enabled, prefix="" *)
+   method  Action interrupt_reqs ((* port="cpu_external_interrupt_req" *) Bit #(N_External_Interrupt_Sources)  reqs);
+
+`ifdef INCLUDE_TANDEM_VERIF
+   // ----------------------------------------------------------------
+   // Optional Tandem Verifier interface.  The data signal is
+   // packed output tuples (n,vb),/ where 'vb' is a vector of
+   // bytes with relevant bytes in locations [0]..[n-1]
+
+      interface AXI4_Stream_Master_IFC #(Wd_SId, Wd_SDest, Wd_SData, Wd_SUser)  tv_verifier_info_tx;
+`endif
+
+`ifdef INCLUDE_GDB_CONTROL
+   // ----------------
+   // JTAG interface
+
+`ifdef JTAG_TAP
+   interface JTAG_IFC jtag;
+`else
+   interface DM_Common::DMI dmi;
+`endif
+`endif
+endinterface
+
+// ================================================================
+
+(* synthesize *)
+module mkP2_Core (P2_Core_IFC);
+
+   // Core: CPU + Near_Mem_IO (CLINT) + PLIC + Debug module (optional) + TV (optional)
+   Core_IFC::Core_IFC #(N_External_Interrupt_Sources)  core <- mkCore;
+
+   // ================================================================
+   // Tie-offs (not used in SSITH GFE)
+
+   // Set core's verbosity
+   rule rl_never (False);
+      core.set_verbosity (?, ?);
+   endrule
+
+   // Tie-offs
+   rule rl_always (True);
+      // Non-maskable interrupt request.
+      core.nmi_req (False);
+   endrule
+
+   // ================================================================
+   // Reset on startup, and also on NDM reset from Debug Module
+   // (NDM reset from Debug Module = "non-debug-module-reset" = reset all except Debug Module)
+
+   Reg #(Bool)          rg_once      <- mkReg (False);
+   Reg #(Maybe #(Bool)) rg_ndm_reset <- mkReg (tagged Invalid);
+
+   rule rl_once (! rg_once);
+      Bool running = True;
+      if (rg_ndm_reset matches tagged Valid False)
+	 running = False;
+      core.cpu_reset_server.request.put (running);
+      rg_once <= True;
+   endrule
+
+   rule rl_reset_response;
+      let running <- core.cpu_reset_server.response.get;
+
+`ifdef INCLUDE_GDB_CONTROL
+      // Respond to Debug module if this is an ndm-reset
+      if (rg_ndm_reset matches tagged Valid .x)
+	 core.ndm_reset_client.response.put (running);
+      rg_ndm_reset <= tagged Invalid;
+`endif
+   endrule
+
+   // ----------------
+   // Also do a reset if requested from Debug Module (NDM = Non-Debug-Module reset)
+
+   rule rl_ndmreset (rg_once);
+`ifdef INCLUDE_GDB_CONTROL
+      let running <- core.ndm_reset_client.request.get;
+      rg_ndm_reset <= tagged Valid running;
+`endif
+
+      rg_once <= False;
+   endrule
+
+   // ================================================================
+`ifdef INCLUDE_GDB_CONTROL
+`ifdef JTAG_TAP
+
+   // Instantiate JTAG TAP controller,
+   // connect to core.dm_dmi;
+   // and export its JTAG interface
+
+   Wire#(Bit#(7)) w_dmi_req_addr <- mkDWire(0);
+   Wire#(Bit#(32)) w_dmi_req_data <- mkDWire(0);
+   Wire#(Bit#(2)) w_dmi_req_op <- mkDWire(0);
+
+   Wire#(Bit#(32)) w_dmi_rsp_data <- mkDWire(0);
+   Wire#(Bit#(2)) w_dmi_rsp_response <- mkDWire(0);
+
+   BusReceiver#(Tuple3#(Bit#(7),Bit#(32),Bit#(2))) bus_dmi_req <- mkBusReceiver;
+   BusSender#(Tuple2#(Bit#(32),Bit#(2))) bus_dmi_rsp <- mkBusSender(unpack(0));
+
+   let jtagtap <- mkJtagTap;
+
+   mkConnection(jtagtap.dmi.req_ready, pack(bus_dmi_req.in.ready));
+   mkConnection(jtagtap.dmi.req_valid, compose(bus_dmi_req.in.valid, unpack));
+   mkConnection(jtagtap.dmi.req_addr, w_dmi_req_addr._write);
+   mkConnection(jtagtap.dmi.req_data, w_dmi_req_data._write);
+   mkConnection(jtagtap.dmi.req_op, w_dmi_req_op._write);
+   mkConnection(jtagtap.dmi.rsp_valid, pack(bus_dmi_rsp.out.valid));
+   mkConnection(jtagtap.dmi.rsp_ready, compose(bus_dmi_rsp.out.ready, unpack));
+   mkConnection(jtagtap.dmi.rsp_data, w_dmi_rsp_data);
+   mkConnection(jtagtap.dmi.rsp_response, w_dmi_rsp_response);
+
+   rule rl_dmi_req;
+      bus_dmi_req.in.data(tuple3(w_dmi_req_addr, w_dmi_req_data, w_dmi_req_op));
+   endrule
+
+   rule rl_dmi_rsp;
+      match {.data, .response} = bus_dmi_rsp.out.data;
+      w_dmi_rsp_data <= data;
+      w_dmi_rsp_response <= response;
+   endrule
+
+   (* preempts = "rl_dmi_req_cpu, rl_dmi_rsp_cpu" *)
+   rule rl_dmi_req_cpu;
+      match {.addr, .data, .op} = bus_dmi_req.out.first;
+      bus_dmi_req.out.deq;
+      case (op)
+	 1: core.dm_dmi.read_addr(addr);
+	 2: begin
+	       core.dm_dmi.write(addr, data);
+	       bus_dmi_rsp.in.enq(tuple2(?, 0));
+	    end
+	 default: bus_dmi_rsp.in.enq(tuple2(?, 2));
+      endcase
+   endrule
+
+   rule rl_dmi_rsp_cpu;
+      let data <- core.dm_dmi.read_data;
+      bus_dmi_rsp.in.enq(tuple2(data, 0));
+   endrule
+
+`endif
+`endif
+
+`ifdef INCLUDE_TANDEM_VERIF
+   let tv_xactor <- mkTV_Xactor;
+   mkConnection (core.tv_verifier_info_get, tv_xactor.tv_in);
+`endif
+
+   // ================================================================
+   // INTERFACE
+
+   // CPU IMem to Fabric master interface
+   interface AXI4_Master_IFC master0 = core.cpu_imem_master;
+
+   // CPU DMem to Fabric master interface
+   interface AXI4_Master_IFC master1 = core.cpu_dmem_master;
+
+   // External interrupts
+   method  Action interrupt_reqs (Bit #(N_External_Interrupt_Sources) reqs);
+      for (Integer j = 0; j < valueOf (N_External_Interrupt_Sources); j = j + 1) begin
+	 Bool req_j = unpack (reqs [j]);
+	 core.core_external_interrupt_sources [j].m_interrupt_req (req_j);
+      end
+   endmethod
+
+`ifdef INCLUDE_TANDEM_VERIF
+   // ----------------------------------------------------------------
+   // Optional Tandem Verifier interface.  The data signal is
+   // packed output tuples (n,vb),/ where 'vb' is a vector of
+   // bytes with relevant bytes in locations [0]..[n-1]
+
+   interface tv_verifier_info_tx = tv_xactor.axi_out;
+`endif
+
+`ifdef INCLUDE_GDB_CONTROL
+   // ----------------------------------------------------------------
+   // Optional Debug Module interfaces
+
+`ifdef JTAG_TAP
+   interface JTAG_IFC jtag = jtagtap.jtag;
+`else
+   interface DMA dmi = core.dm_dmi;
+`endif
+
+`endif
+endmodule
+
+// ================================================================
+// The TV to AXI4 Stream transactor
+
+`ifdef INCLUDE_TANDEM_VERIF
+
+// ================================================================
+// TV AXI4 Stream Parameters
+
+typedef SizeOf #(Info_CPU_to_Verifier)Wd_SData;
+typedef 0 Wd_SDest;
+typedef 0 Wd_SUser;
+typedef 0 Wd_SId;
+
+// ================================================================
+
+interface TV_Xactor;
+   interface Put #(Info_CPU_to_Verifier) tv_in;
+   interface AXI4_Stream_Master_IFC #(Wd_SId, Wd_SDest, Wd_SData, Wd_SUser)  axi_out;
+endinterface
+
+function AXI4_Stream #(Wd_SId, Wd_SDest, Wd_SData, Wd_SUser) fn_TVToAxiS (Info_CPU_to_Verifier x);
+   return AXI4_Stream {tid: ?,
+		       tdata: pack(x),
+		       tstrb: '1,
+		       tkeep: '1,
+		       tlast: True,
+		       tdest: ?,
+		       tuser: ? };
+endfunction
+
+(*synthesize*)
+module mkTV_Xactor (TV_Xactor);
+   AXI4_Stream_Master_Xactor_IFC #(Wd_SId, Wd_SDest, Wd_SData, Wd_SUser)
+                               tv_xactor <- mkAXI4_Stream_Master_Xactor;
+
+   interface Put tv_in;
+      method Action put(x);
+	 toPut(tv_xactor.i_stream).put(fn_TVToAxiS(x));
+      endmethod
+   endinterface
+
+   interface axi_out = tv_xactor.axi_side;
+endmodule
+`endif
+
+// ================================================================
+
+endpackage

--- a/hw/src_BSV/UART_Model.bsv
+++ b/hw/src_BSV/UART_Model.bsv
@@ -236,7 +236,7 @@ module mkUART (UART_IFC);
    // Virtual read-only register IIR
 
    function Bit #(8) fn_iir ();
-      Bit #(8) iir = 0;
+      Bit #(8) iir = uart_iir_none;
 
       if (   ((rg_ier & uart_ier_erbfi) != 0)    // Rx interrupt enabled
 	  && ((rg_lsr & uart_lsr_dr)    != 0))   // data ready

--- a/src/dts/devicetree.dts
+++ b/src/dts/devicetree.dts
@@ -6,7 +6,8 @@
 	compatible = "unknown,unknown";
 	model = "unknown,unknown";
 	chosen {
-		bootargs = "earlyprintk console=hvc0 loglevel=15";
+		bootargs = "earlyprintk console=ttyS0,115200 loglevel=15";
+		stdout-path = &ns16550;
 	};
 	cpus {
 		#address-cells = <1>;
@@ -63,6 +64,14 @@
 			riscv,max-priority = <7>;
 			riscv,ndev = <16>;
 		};
+		ns16550: uart@62300000 {
+			current-speed = <115200>;
+			compatible = "ns16550a";
+			interrupts-extended = <&plic 1>;
+			reg = <0x62300000 0x1000>;
+			clock-frequency = <125000000>;
+			reg-shift = <2>;
+		};
 	};
 
 	virtio_block@40000000 {
@@ -83,8 +92,4 @@
 		interrupt-parent = <&plic>;
 		interrupts = <2>;
 	};
-
-    htif {
-        compatible = "ucb,htif0";
-    };
 };

--- a/src/dts/devicetree.dts
+++ b/src/dts/devicetree.dts
@@ -76,20 +76,17 @@
 
 	virtio_block@40000000 {
 		compatible = "virtio,mmio";
+		interrupts-extended = <&plic 2>;
 		reg = <0x40000000 0x100>;
-		interrupt-parent = <&plic>;
-		interrupts = <0>;
 	};
 	virtio_block@40001000 {
 		compatible = "virtio,mmio";
+		interrupts-extended = <&plic 3>;
 		reg = <0x40001000 0x1000>;
-		interrupt-parent = <&plic>;
-		interrupts = <1>;
 	};
 	virtio_block@40002000 {
 		compatible = "virtio,mmio";
+		interrupts-extended = <&plic 4>;
 		reg = <0x40002000 0x1000>;
-		interrupt-parent = <&plic>;
-		interrupts = <2>;
 	};
 };

--- a/src/fpga.cpp
+++ b/src/fpga.cpp
@@ -242,7 +242,7 @@ void AWSP2_Response::io_wdata(uint64_t wdata, uint8_t wstrb) {
         pr->write_func(pr->opaque, offset, wdata, size_log2);
     } else if (awaddr == 0x60000000) {
         console_putchar(wdata);
-    } else if (awaddr == 0x10001008 || awaddr == 0x50001008) {
+    } else if (awaddr == (fpga->htif_base_addr + TOHOST_OFFSET)) {
         // tohost
         uint8_t dev = (wdata >> 56) & 0xFF;
         uint8_t cmd = (wdata >> 48) & 0xFF;
@@ -260,7 +260,7 @@ void AWSP2_Response::io_wdata(uint64_t wdata, uint8_t wstrb) {
         } else {
             fprintf(stderr, "\nHTIF: dev=%d cmd=%02x payload=%08lx\n", dev, cmd, payload);
         }
-    } else if (awaddr == 0x10001000) {
+    } else if (awaddr == (fpga->htif_base_addr + FROMHOST_OFFSET)) {
         //fprintf(stderr, "\nHTIF: awaddr %08x wdata=%08lx\n", awaddr, wdata);
     } else {
         if (debug_stray_io) fprintf(stderr, "io_wdata wdata=%lx wstrb=%x\n", wdata, wstrb);

--- a/src/fpga.cpp
+++ b/src/fpga.cpp
@@ -3,6 +3,7 @@
 
 #define TOHOST_OFFSET 0
 #define FROMHOST_OFFSET 8
+#define FIRST_VIRTIO_IRQ 1
 
 static int debug_virtio = 0;
 static int debug_stray_io = 0;
@@ -290,7 +291,7 @@ void AWSP2_Response::console_putchar(uint64_t wdata) {
 }
 
 AWSP2::AWSP2(int id, const Rom &rom)
-  : response(0), rom(rom), last_addr(0), wdata_count(0), wid(0), start_of_line(1), uart_enabled(0)
+  : response(0), rom(rom), last_addr(0), wdata_count(0), wid(0), start_of_line(1), uart_enabled(0), virtio_devices(FIRST_VIRTIO_IRQ)
 {
     sem_init(&sem, 0, 0);
     response = new AWSP2_Response(id, this);

--- a/src/fpga.h
+++ b/src/fpga.h
@@ -115,7 +115,8 @@ class AWSP2 {
     int stop_capture;
     int display_tandem;
     bsvvector_Luint8_t_L64 pcis_rsp_data;
-    uint64_t htif_base_addr;
+    uint64_t tohost_addr;
+    uint64_t fromhost_addr;
     uint64_t uart_enabled;
 
     std::mutex client_mutex;
@@ -163,6 +164,8 @@ public:
     void process_io();
 
     void set_htif_base_addr(uint64_t baseaddr);
+    void set_tohost_addr(uint64_t addr);
+    void set_fromhost_addr(uint64_t addr);
     void set_uart_enabled(bool enabled);
 
  private:

--- a/src/loadelf.cpp
+++ b/src/loadelf.cpp
@@ -195,9 +195,9 @@ uint64_t loadElf(IMemory *mem, const char *elf_filename, size_t max_mem_size, ui
                     *tohost_address = shdr.sh_addr;
                 }
             } else {
-                if (max_addr >= max_mem_size) {
-                    fprintf(stdout, "INTERNAL ERROR: max_addr (0x%0lx) > buffer size (0x%0lx) -1-\n",
-                            max_addr, max_mem_size);
+                if (data->d_size > max_mem_size) {
+                    fprintf(stdout, "INTERNAL ERROR: section size (0x%0lx) > buffer size (0x%0lx)\n",
+                            data->d_size, max_mem_size);
                     fprintf(stdout, "    Please increase the #define in this program, recompile, and run again\n");
                     fprintf(stdout, "    Abandoning this run\n");
                     exit(1);

--- a/src/loadelf.cpp
+++ b/src/loadelf.cpp
@@ -192,7 +192,7 @@ uint64_t loadElf(IMemory *mem, const char *elf_filename, size_t max_mem_size, ui
 
             if (strcmp(sec_name, ".tohost") == 0 || strcmp(sec_name, ".htif") == 0) {
                 if (tohost_address != 0) {
-                    *tohost_address = shdr.sh_addr;
+                    *tohost_address = shdr.sh_addr - base_va + base_pa;
                 }
             } else {
                 if (data->d_size > max_mem_size) {

--- a/src/loadelf.cpp
+++ b/src/loadelf.cpp
@@ -192,7 +192,7 @@ uint64_t loadElf(IMemory *mem, const char *elf_filename, size_t max_mem_size, ui
 
             if (strcmp(sec_name, ".tohost") == 0 || strcmp(sec_name, ".htif") == 0) {
                 if (tohost_address != 0) {
-                    *tohost_address = shdr.sh_addr - base_va + base_pa;
+                    *tohost_address = section_base_addr;
                 }
             } else {
                 if (data->d_size > max_mem_size) {
@@ -204,7 +204,7 @@ uint64_t loadElf(IMemory *mem, const char *elf_filename, size_t max_mem_size, ui
                 }
 
                 if (shdr.sh_type != SHT_NOBITS) {
-                    mem->write(shdr.sh_addr - base_va + base_pa, (uint32_t *)data->d_buf, data->d_size);
+                    mem->write(section_base_addr, (uint32_t *)data->d_buf, data->d_size);
                 }
             }
 

--- a/src/loadelf.cpp
+++ b/src/loadelf.cpp
@@ -233,6 +233,7 @@ uint64_t loadElf(IMemory *mem, const char *elf_filename, size_t max_mem_size, ui
 
             }
 
+            fprintf(stdout, "Parsed\n");
         }
         else {
             fprintf(stdout, "Ignored\n");

--- a/src/loadelf.cpp
+++ b/src/loadelf.cpp
@@ -213,45 +213,6 @@ uint64_t loadElf(IMemory *mem, const char *elf_filename, size_t max_mem_size, ui
 
         }
 
-        else if (   ((shdr.sh_type == SHT_PROGBITS)
-                || (shdr.sh_type == SHT_NOBITS)
-                || (shdr.sh_type == SHT_INIT_ARRAY)
-                || (shdr.sh_type == SHT_FINI_ARRAY))
-            && ((shdr.sh_flags & SHF_WRITE)
-                || (shdr.sh_flags & SHF_ALLOC)
-                || (shdr.sh_flags & SHF_EXECINSTR))) {
-
-            Elf_Data *data = 0;
-            data = elf_getdata (scn, data);
-
-            // n_initialized += data->d_size;
-            uint32_t section_base_addr = shdr.sh_addr - base_va + base_pa;
-            size_t max_addr = (section_base_addr + data->d_size - 1);    // shdr.sh_size + 4;
-            fprintf(stderr, "section_base_addr %08x max_addr %08lx\n", section_base_addr, max_addr);
-
-            if (strcmp(sec_name, ".tohost") == 0 || strcmp(sec_name, ".htif") == 0) {
-                if (tohost_address != 0) {
-                    *tohost_address = shdr.sh_addr;
-                }
-            } else {
-                if (max_addr >= max_mem_size) {
-                    fprintf(stdout, "INTERNAL ERROR: max_addr (0x%0lx) > buffer size (0x%0lx)\n",
-                            max_addr, max_mem_size);
-                    fprintf(stdout, "    Please increase the #define in this program, recompile, and run again\n");
-                    fprintf(stdout, "    Abandoning this run\n");
-                    //exit(1);
-                }
-
-                if (shdr.sh_type != SHT_NOBITS) {
-                    mem->write(shdr.sh_addr - base_va + base_pa, (uint32_t *)data->d_buf, data->d_size);
-                }
-            }
-
-            fprintf (stdout, "addr %16lx to addr %16lx; size 0x%8lx (= %0ld) bytes\n",
-                     shdr.sh_addr, shdr.sh_addr + data->d_size, data->d_size, data->d_size);
-
-        }
-
         // If we find the symbol table, search for symbols of interest
         else if (shdr.sh_type == SHT_SYMTAB) {
 

--- a/src/loadelf.cpp
+++ b/src/loadelf.cpp
@@ -90,7 +90,7 @@ void AWSP2_Memory::write(uint32_t start_addr, const uint32_t *data, size_t num_b
 }
 
 
-uint64_t loadElf(IMemory *mem, const char *elf_filename, size_t max_mem_size, uint64_t *tohost_address)
+uint64_t loadElf(IMemory *mem, const char *elf_filename, size_t max_mem_size, AWSP2 *fpga)
 {
     // Verify the elf library version
     if (elf_version(EV_CURRENT) == EV_NONE) {
@@ -190,10 +190,12 @@ uint64_t loadElf(IMemory *mem, const char *elf_filename, size_t max_mem_size, ui
             size_t max_addr = (section_base_addr + data->d_size - 1);    // shdr.sh_size + 4;
             fprintf(stderr, "section_base_addr %08x max_addr %08lx\n", section_base_addr, max_addr);
 
-            if (strcmp(sec_name, ".tohost") == 0 || strcmp(sec_name, ".htif") == 0) {
-                if (tohost_address != 0) {
-                    *tohost_address = section_base_addr;
-                }
+            if (strcmp(sec_name, ".htif") == 0) {
+                fpga->set_htif_base_addr(section_base_addr);
+            } else if (strcmp(sec_name, ".tohost") == 0) {
+                fpga->set_tohost_addr(section_base_addr);
+            } else if (strcmp(sec_name, ".fromhost") == 0) {
+                fpga->set_fromhost_addr(section_base_addr);
             } else {
                 if (data->d_size > max_mem_size) {
                     fprintf(stdout, "INTERNAL ERROR: section size (0x%0lx) > buffer size (0x%0lx)\n",

--- a/src/loadelf.cpp
+++ b/src/loadelf.cpp
@@ -208,8 +208,8 @@ uint64_t loadElf(IMemory *mem, const char *elf_filename, size_t max_mem_size, ui
                 }
             }
 
-            fprintf (stdout, "addr %16lx to addr %16lx; size 0x%8lx (= %0ld) bytes\n",
-                     shdr.sh_addr, shdr.sh_addr + data->d_size, data->d_size, data->d_size);
+            fprintf (stdout, "addr %16x to addr %16lx; size 0x%8lx (= %0ld) bytes\n",
+                     section_base_addr, section_base_addr + data->d_size, data->d_size, data->d_size);
 
         }
 

--- a/src/loadelf.h
+++ b/src/loadelf.h
@@ -35,4 +35,4 @@ public:
     virtual void write(uint32_t start_addr, const uint32_t *data, size_t num_bytes);
 };
 
-uint64_t loadElf(IMemory *mem, const char *elf_filename, size_t max_mem_size, uint64_t *tohost_address);
+uint64_t loadElf(IMemory *mem, const char *elf_filename, size_t max_mem_size, AWSP2 *fpga);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -234,12 +234,8 @@ int main(int argc, char * const *argv)
         fprintf(stderr, "Using shared memory loader\n");
     }
     IMemory *memifc = usemem ? static_cast<IMemory *>(&mem) : static_cast<IMemory *>(&fpgamem);
-    uint64_t tohost_address = 0;
-    uint64_t elf_entry = loadElf(memifc, elf_filename, dram_alloc_sz, &tohost_address);
-    fprintf(stderr, "elf_entry=%08lx tohost_address=%08lx\n", elf_entry, tohost_address);
-    if (tohost_address) {
-        fpga->set_htif_base_addr(tohost_address);
-    }
+    uint64_t elf_entry = loadElf(memifc, elf_filename, dram_alloc_sz, fpga);
+    fprintf(stderr, "elf_entry=%08lx\n", elf_entry);
 
     if (!entry)
         entry = elf_entry;

--- a/src/virtiodevices.cpp
+++ b/src/virtiodevices.cpp
@@ -52,10 +52,10 @@ void VirtioDevices::set_dram_buffer(uint8_t *buf) {
 }
 
 
-VirtioDevices::VirtioDevices() {
+VirtioDevices::VirtioDevices(int first_irq_num) {
     mem_map = phys_mem_map_init();
     irq = (IRQSignal *)mallocz(32 * sizeof(IRQSignal));
-    irq_num = 0;
+    irq_num = first_irq_num;
     virtio_bus = (VIRTIOBusDef *)mallocz(sizeof(*virtio_bus));
     virtio_bus->mem_map = mem_map;
     virtio_bus->addr = 0x40000000;
@@ -65,7 +65,6 @@ VirtioDevices::VirtioDevices() {
 
     // set up a network device
     virtio_bus->irq = &irq[irq_num++];
-    irq_init(virtio_bus->irq, awsp2_set_irq, (void *)22, 0);
     ethernet_device = slirp_open();
     virtio_net = virtio_net_init(virtio_bus, ethernet_device);
     fprintf(stderr, "ethernet device %p virtio net device %p at addr %08lx\n", ethernet_device, virtio_net, virtio_bus->addr);

--- a/src/virtiodevices.h
+++ b/src/virtiodevices.h
@@ -22,7 +22,7 @@ class VirtioDevices {
   int irq_num;
 
  public:
-  VirtioDevices();
+  VirtioDevices(int first_irq_num = 0);
   ~VirtioDevices();
   PhysMemoryRange *get_phys_mem_range(uint64_t paddr);
   void set_dram_buffer(uint8_t *buf);


### PR DESCRIPTION
I am now able to build src_AWS_P2 for Verilator and load ELF files into the simulation. However, I cannot yet reproduce the simulation working; the ISA tests are seemingly correctly loaded, but execution hangs once the core is resumed at:

```
6061: TOP.mkXsimTop.top.lAWSP2_p2_core.core.debug_module.dm_run_control.dmcontrol_write: hart0 resume request
6292: D_MMU_Cache: cache size 8 KB, associativity 2, line size 64 bytes (= 8 XLEN words)
```