### PR TITLE
More VirtIO-Related Fixes

### DIFF
--- a/src/fpga.cpp
+++ b/src/fpga.cpp
@@ -279,7 +279,7 @@ void AWSP2_Response::uart_tohost(uint8_t ch) {
 
 void AWSP2_Response::console_putchar(uint64_t wdata) {
     if (fpga->start_of_line) {
-        printf("\nCONSOLE: ");
+        printf("CONSOLE: ");
         fpga->start_of_line = 0;
     }
     fputc(wdata, stdout);

--- a/src/fpga.cpp
+++ b/src/fpga.cpp
@@ -197,7 +197,7 @@ void AWSP2_Response::io_araddr(uint32_t araddr, uint16_t arlen, uint16_t arid)
             fpga->request->io_rdata(val, arid, 0, last);
             if (debug_virtio)
                 fprintf(stderr, "virtio araddr %0x device addr %08lx offset %08x len %d val %08lx last %d\n",
-                        araddr + offset, pr->addr, offset, arlen, val, last);
+                        araddr + i * 4, pr->addr, offset, arlen, val, last);
             offset += 4;
         }
     } else if (fpga->rom.base <= araddr && araddr < fpga->rom.limit) {

--- a/src/tinyemu/virtio.c
+++ b/src/tinyemu/virtio.c
@@ -1097,7 +1097,7 @@ static int virtio_block_recv_request(VIRTIODevice *s, int queue_idx,
     VIRTIOBlockDevice *s1 = (VIRTIOBlockDevice *)s;
     BlockDevice *bs = s1->bs;
     BlockRequestHeader h;
-    uint8_t *buf;
+    uint8_t *buf, buf1[1];
     int len, ret;
 
     if (s1->req_in_progress)
@@ -1138,6 +1138,9 @@ static int virtio_block_recv_request(VIRTIODevice *s, int queue_idx,
         }
         break;
     default:
+        buf1[0] = VIRTIO_BLK_S_UNSUPP;
+        memcpy_to_queue(s, queue_idx, desc_idx, 0, buf1, sizeof(buf1));
+        virtio_consume_desc(s, queue_idx, desc_idx, 1);
         break;
     }
     return 0;

--- a/src/virtiodevices.cpp
+++ b/src/virtiodevices.cpp
@@ -22,7 +22,7 @@ extern AWSP2 *fpga;
 
 void awsp2_set_irq(void *opaque, int irq_num, int level)
 {
-    fprintf(stderr, "%s: irq_num=%d level=%d\n", __FUNCTION__, irq_num, level);
+    if (debug) fprintf(stderr, "%s: irq_num=%d level=%d\n", __FUNCTION__, irq_num, level);
     if (level)
         fpga->irq_set_levels(1 << irq_num);
     else
@@ -158,7 +158,7 @@ int VirtioDevices::perform_pending_actions()
 {
     if (virtio_net != 0) {
 	if (virtio_has_pending_actions(virtio_net)) {
-	    fprintf(stderr, "performing pending net actions\n");
+	    if (debug) fprintf(stderr, "performing pending net actions\n");
 	    virtio_perform_pending_actions(virtio_net);
 	}
     }


### PR DESCRIPTION
The important one is the VIRTIO_BLK_S_UNSUPP change, which is a bug in upstream TinyEMU. Everything else is to suppress debug output so you just see the guest's console with nothing in between in a default build.

With https://reviews.freebsd.org/D24681 applied, FreeBSD can now boot from a VirtIO block device, albeit excruciatingly slowly (about an hour) due to using DMI requests for the VirtIO reads/writes.