### PR TITLE
More VirtIO Fixes

### DIFF
--- a/src/dts/devicetree.dts
+++ b/src/dts/devicetree.dts
@@ -89,4 +89,9 @@
 		interrupts-extended = <&plic 4>;
 		reg = <0x40002000 0x1000>;
 	};
+	virtio_block@40003000 {
+		compatible = "virtio,mmio";
+		interrupts-extended = <&plic 5>;
+		reg = <0x40003000 0x1000>;
+	};
 };

--- a/src/fpga.cpp
+++ b/src/fpga.cpp
@@ -609,6 +609,11 @@ void AWSP2::process_io()
     }
 }
 
+void AWSP2::wait_for_io(int timeout)
+{
+    virtio_devices.wait_for_pending_actions(timeout);
+}
+
 void AWSP2::set_htif_base_addr(uint64_t baseaddr)
 {
     tohost_addr = baseaddr + TOHOST_OFFSET;

--- a/src/fpga.h
+++ b/src/fpga.h
@@ -123,6 +123,7 @@ class AWSP2 {
     bsvvector_Luint8_t_L64 pcis_rsp_data;
     uint64_t tohost_addr;
     uint64_t fromhost_addr;
+    uint64_t htif_enabled;
     uint64_t uart_enabled;
 
     std::mutex client_mutex;
@@ -172,6 +173,7 @@ public:
     void set_htif_base_addr(uint64_t baseaddr);
     void set_tohost_addr(uint64_t addr);
     void set_fromhost_addr(uint64_t addr);
+    void set_htif_enabled(bool enabled);
     void set_uart_enabled(bool enabled);
 
  private:

--- a/src/fpga.h
+++ b/src/fpga.h
@@ -169,6 +169,7 @@ public:
 
     VirtioDevices &get_virtio_devices() { return virtio_devices; }
     void process_io();
+    void wait_for_io(int timeout);
 
     void set_htif_base_addr(uint64_t baseaddr);
     void set_tohost_addr(uint64_t addr);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -275,7 +275,7 @@ int main(int argc, char * const *argv)
             fpga->resume();
         }
 
-        sleep(sleep_seconds);
+        fpga->wait_for_io(sleep_seconds);
     }
     return 0;
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -171,6 +171,7 @@ int main(int argc, char * const *argv)
     Rom rom = { 0x00001000, 0x00010000, (uint64_t *)romBuffer };
     fpga = new AWSP2(IfcNames_AWSP2_ResponseH2S, rom);
     fpga->set_dram_buffer(dramBuffer);
+    fpga->set_htif_enabled(htif_enabled);
     fpga->set_uart_enabled(uart_enabled);
 
     for (string block_file: block_files) {

--- a/src/tinyemu/virtio.h
+++ b/src/tinyemu/virtio.h
@@ -68,6 +68,7 @@ void virtio_set_debug(VIRTIODevice *s, int debug_flags);
 
 int virtio_has_pending_actions(VIRTIODevice *s);
 void virtio_perform_pending_actions(VIRTIODevice *s);
+void virtio_wait_for_pending_actions(int timeout);
 
 /* block device */
 

--- a/src/tinyemu/virtio.h
+++ b/src/tinyemu/virtio.h
@@ -129,6 +129,10 @@ int virtio_console_get_write_len(VIRTIODevice *s);
 int virtio_console_write_data(VIRTIODevice *s, const uint8_t *buf, int buf_len);
 void virtio_console_resize_event(VIRTIODevice *s, int width, int height);
 
+/* entropy device */
+
+VIRTIODevice *virtio_entropy_init(VIRTIOBusDef *bus);
+
 /* input device */
 
 typedef enum {

--- a/src/virtiodevices.cpp
+++ b/src/virtiodevices.cpp
@@ -158,6 +158,7 @@ int VirtioDevices::has_pending_actions()
 {
     return (virtio_net != 0 && virtio_has_pending_actions(virtio_net))
 	|| (virtio_entropy != 0 && virtio_has_pending_actions(virtio_entropy))
+	|| (virtio_console != 0 && virtio_has_pending_actions(virtio_console))
 	|| (virtio_block != 0 && virtio_has_pending_actions(virtio_block));
 }
 
@@ -171,6 +172,9 @@ int VirtioDevices::perform_pending_actions()
     }
     if (virtio_entropy != 0) {
 	virtio_perform_pending_actions(virtio_entropy);
+    }
+    if (virtio_console != 0) {
+	virtio_perform_pending_actions(virtio_console);
     }
     if (virtio_block != 0) {
 	virtio_perform_pending_actions(virtio_block);

--- a/src/virtiodevices.cpp
+++ b/src/virtiodevices.cpp
@@ -109,7 +109,7 @@ void VirtioDevices::process_io()
     int stdin_fd = 0;
     int fd_max = -1;
     fd_set rfds,  wfds, efds;
-    int delay = 10; // ms
+    int delay = 0; // ms
     struct timeval tv;
 
     FD_ZERO(&rfds);
@@ -179,6 +179,11 @@ int VirtioDevices::perform_pending_actions()
     if (virtio_block != 0) {
 	virtio_perform_pending_actions(virtio_block);
     }
+}
+
+void VirtioDevices::wait_for_pending_actions(int timeout)
+{
+    virtio_wait_for_pending_actions(timeout);
 }
 
 uint16_t virtio_read16(VIRTIODevice *s, virtio_phys_addr_t addr)

--- a/src/virtiodevices.cpp
+++ b/src/virtiodevices.cpp
@@ -68,6 +68,12 @@ VirtioDevices::VirtioDevices(int first_irq_num) {
     ethernet_device = slirp_open();
     virtio_net = virtio_net_init(virtio_bus, ethernet_device);
     fprintf(stderr, "ethernet device %p virtio net device %p at addr %08lx\n", ethernet_device, virtio_net, virtio_bus->addr);
+
+    // set up an entropy device
+    //virtio_bus->addr += 0x1000;
+    //virtio_bus->irq = &irq[irq_num++];
+    //virtio_entropy = virtio_entropy_init(virtio_bus);
+    //fprintf(stderr, "virtio entropy device %p at addr %08lx\n", virtio_entropy, virtio_bus->addr);
 }
 
 VirtioDevices::~VirtioDevices() {
@@ -151,6 +157,7 @@ void VirtioDevices::process_io()
 int VirtioDevices::has_pending_actions()
 {
     return (virtio_net != 0 && virtio_has_pending_actions(virtio_net))
+	|| (virtio_entropy != 0 && virtio_has_pending_actions(virtio_entropy))
 	|| (virtio_block != 0 && virtio_has_pending_actions(virtio_block));
 }
 
@@ -161,6 +168,9 @@ int VirtioDevices::perform_pending_actions()
 	    if (debug) fprintf(stderr, "performing pending net actions\n");
 	    virtio_perform_pending_actions(virtio_net);
 	}
+    }
+    if (virtio_entropy != 0) {
+	virtio_perform_pending_actions(virtio_entropy);
     }
     if (virtio_block != 0) {
 	virtio_perform_pending_actions(virtio_block);

--- a/src/virtiodevices.h
+++ b/src/virtiodevices.h
@@ -30,6 +30,7 @@ class VirtioDevices {
   void process_io();
   int has_pending_actions();
   int perform_pending_actions();
+  void wait_for_pending_actions(int timeout);
   void add_virtio_block_device(std::string filename);
   void add_virtio_console_device();
 };

--- a/src/virtiodevices.h
+++ b/src/virtiodevices.h
@@ -18,6 +18,7 @@ class VirtioDevices {
   VIRTIODevice *virtio_console;
   VIRTIODevice *virtio_block;
   VIRTIODevice *virtio_net;
+  VIRTIODevice *virtio_entropy;
   IRQSignal *irq;
   int irq_num;
 


### PR DESCRIPTION
Whilst we now have a VirtIO console, BBL still needs a real UART, and given FreeBSD then won't use it for the boot console or getty I think we should continue to just use the UART, but as I saw what the bug was when adding the entropy device I thought I might as well fix it for completeness.

The block device fix seems to make boot about 25% faster; still very slow, but a step in the right direction, and the issue would have become a bottleneck with proper DMA.