### PR TITLE
Separate out AWS SoC fabric from Flute internal fabric

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ cache:
 sudo: no
 os:
 - linux
+dist: bionic
 script:
 - mkdir build  
 - cd build; cmake -DFPGA=0 ..; make

--- a/hw/src_BSV/AWSP2.bsv
+++ b/hw/src_BSV/AWSP2.bsv
@@ -33,15 +33,11 @@ import PLIC :: *;    // for PLIC_Source_IFC type which is exposed at P2_Core int
 import Semi_FIFOF :: *;
 
 // Main Fabric
-`ifdef HAVE_BLUESTUFF_AXI
-import Bluespec_AXI4_Types   :: *;
-import Bluespec_AXI4_Fabric  :: *;
-`else
-import AXI4_Types   :: *;
-import AXI4_Fabric  :: *;
-`endif
-import Fabric_Defs  :: *;
-import AXI4_Deburster :: *;
+import AWS_AXI4_Types   :: *;
+import AWS_AXI4_Fabric  :: *;
+import AWS_Fabric_Defs  :: *;
+import AWS_AXI4_Deburster :: *;
+import AWS_AXI4_Connection :: *;
 import AXI_Mem_Controller :: *;
 import AXI_RAM        :: *;
 

--- a/hw/src_BSV/AWSP2_IFC.bsv
+++ b/hw/src_BSV/AWSP2_IFC.bsv
@@ -1,10 +1,6 @@
 
 import Vector     :: *;
-`ifdef HAVE_BLUESTUFF_AXI
-import Bluespec_AXI4_Types :: *;
-`else
-import AXI4_Types :: *;
-`endif
+import AWS_AXI4_Types :: *;
 
 interface AWSP2_Request;
   method Action set_debug_verbosity(Bit#(4) verbosity);

--- a/hw/src_BSV/AWS_AXI4_Connection.bsv
+++ b/hw/src_BSV/AWS_AXI4_Connection.bsv
@@ -1,0 +1,78 @@
+import AWS_AXI4_Types :: *;
+import Connectable :: *;
+
+import AXI4_Types :: *;
+
+instance Connectable #(AXI4_Types::AXI4_Master_IFC    #(m_wd_id, wd_addr, wd_data, wd_user),
+		       AWS_AXI4_Types::AXI4_Slave_IFC #(s_wd_id, wd_addr, wd_data, wd_user))
+   provisos (Add #(a__, m_wd_id, s_wd_id));
+
+   module mkConnection #(AXI4_Types::AXI4_Master_IFC     #(m_wd_id, wd_addr, wd_data, wd_user) axim,
+			 AWS_AXI4_Types::AXI4_Slave_IFC  #(s_wd_id, wd_addr, wd_data, wd_user) axis)
+		       (Empty);
+
+      (* fire_when_enabled, no_implicit_conditions *)
+      rule rl_wr_addr_channel;
+	 axis.m_awvalid (axim.m_awvalid,
+			 zeroExtend(axim.m_awid),
+			 axim.m_awaddr,
+			 axim.m_awlen,
+			 axim.m_awsize,
+			 axim.m_awburst,
+			 axim.m_awlock,
+			 axim.m_awcache,
+			 axim.m_awprot,
+			 axim.m_awqos,
+			 axim.m_awregion,
+			 axim.m_awuser);
+	 axim.m_awready (axis.m_awready);
+      endrule
+
+      (* fire_when_enabled, no_implicit_conditions *)
+      rule rl_wr_data_channel;
+	 axis.m_wvalid (axim.m_wvalid,
+			axim.m_wdata,
+			axim.m_wstrb,
+			axim.m_wlast,
+			axim.m_wuser);
+	 axim.m_wready (axis.m_wready);
+      endrule
+
+      (* fire_when_enabled, no_implicit_conditions *)
+      rule rl_wr_response_channel;
+	 axim.m_bvalid (axis.m_bvalid,
+			truncate(axis.m_bid),
+			axis.m_bresp,
+			axis.m_buser);
+	 axis.m_bready (axim.m_bready);
+      endrule
+
+      (* fire_when_enabled, no_implicit_conditions *)
+      rule rl_rd_addr_channel;
+	 axis.m_arvalid (axim.m_arvalid,
+			 zeroExtend(axim.m_arid),
+			 axim.m_araddr,
+			 axim.m_arlen,
+			 axim.m_arsize,
+			 axim.m_arburst,
+			 axim.m_arlock,
+			 axim.m_arcache,
+			 axim.m_arprot,
+			 axim.m_arqos,
+			 axim.m_arregion,
+			 axim.m_aruser);
+	 axim.m_arready (axis.m_arready);
+      endrule
+
+      (* fire_when_enabled, no_implicit_conditions *)
+      rule rl_rd_data_channel;
+	 axim.m_rvalid (axis.m_rvalid,
+			truncate(axis.m_rid),
+			axis.m_rdata,
+			axis.m_rresp,
+			axis.m_rlast,
+			axis.m_ruser);
+	 axis.m_rready (axim.m_rready);
+      endrule
+   endmodule
+endinstance

--- a/hw/src_BSV/AWS_AXI4_Deburster.bsv
+++ b/hw/src_BSV/AWS_AXI4_Deburster.bsv
@@ -1,6 +1,6 @@
 // Copyright (c) 2019 Bluespec, Inc. All Rights Reserved
 
-package AXI4_Deburster;
+package AWS_AXI4_Deburster;
 
 // ================================================================
 // This package defines a AXI4-slave-to-AXI4-slave conversion module.
@@ -24,11 +24,7 @@ import Cur_Cycle  :: *;
 // Project imports
 
 import Semi_FIFOF :: *;
-`ifdef HAVE_BLUESTUFF_AXI
-import Bluespec_AXI4_Types :: *;
-`else
-import AXI4_Types :: *;
-`endif
+import AWS_AXI4_Types :: *;
 
 // ================================================================
 // The interface for the fabric module
@@ -323,4 +319,4 @@ endmodule
 
 // ================================================================
 
-endpackage: AXI4_Deburster
+endpackage: AWS_AXI4_Deburster

--- a/hw/src_BSV/AWS_AXI4_Fabric.bsv
+++ b/hw/src_BSV/AWS_AXI4_Fabric.bsv
@@ -1,6 +1,6 @@
 // Copyright (c) 2013-2019 Bluespec, Inc. All Rights Reserved
 
-package Bluespec_AXI4_Fabric;
+package AWS_AXI4_Fabric;
 
 // ================================================================
 // This package defines a fabric connecting CPUs, Memories and DMAs
@@ -23,7 +23,7 @@ import Cur_Cycle  :: *;
 // Project imports
 
 import Semi_FIFOF :: *;
-import Bluespec_AXI4_Types :: *;
+import AWS_AXI4_Types :: *;
 
 // ================================================================
 // The interface for the fabric module
@@ -445,4 +445,4 @@ endmodule
 
 // ================================================================
 
-endpackage: Bluespec_AXI4_Fabric
+endpackage: AWS_AXI4_Fabric

--- a/hw/src_BSV/AWS_AXI4_Types.bsv
+++ b/hw/src_BSV/AWS_AXI4_Types.bsv
@@ -1,6 +1,6 @@
 // Copyright (c) 2019 Bluespec, Inc.  All Rights Reserved
 
-package Bluespec_AXI4_Types;
+package AWS_AXI4_Types;
 
 // ================================================================
 // Facilities for ARM AXI4, consisting of 5 independent channels:

--- a/hw/src_BSV/AWS_Fabric_Defs.bsv
+++ b/hw/src_BSV/AWS_Fabric_Defs.bsv
@@ -1,6 +1,6 @@
 // Copyright (c) 2018-2020 Bluespec, Inc. All Rights Reserved
 
-package Fabric_Defs;
+package AWS_Fabric_Defs;
 
 // ================================================================
 // Defines key parameters of the AXI4/AXI4-Lite system interconnect
@@ -22,7 +22,7 @@ package Fabric_Defs;
 // ================================================================
 // Project imports
 
-import Bluespec_AXI4_Types :: *;
+import AWS_AXI4_Types :: *;
 
 // ================================================================
 // Fabric parameters

--- a/hw/src_BSV/AXI_Mem_Controller.bsv
+++ b/hw/src_BSV/AXI_Mem_Controller.bsv
@@ -73,12 +73,8 @@ import ByteLane   :: *;
 // ================================================================
 // Project imports
 
-`ifdef HAVE_BLUESTUFF_AXI
-import Bluespec_AXI4_Types  :: *;
-`else
-import AXI4_Types  :: *;
-`endif
-import Fabric_Defs :: *;
+import AWS_AXI4_Types  :: *;
+import AWS_Fabric_Defs :: *;
 import SoC_Map     :: *;
 
 // ================================================================

--- a/hw/src_BSV/AXI_RAM.bsv
+++ b/hw/src_BSV/AXI_RAM.bsv
@@ -6,33 +6,17 @@ import FIFO         :: *;
 import GetPut       :: *;
 
 import Semi_FIFOF   :: *;
-`ifdef HAVE_BLUESTUFF_AXI
-import AXI4         :: *;
-`else
-import AXI4_Types   :: *;
-`endif
+import AWS_AXI4_Types   :: *;
 
-`ifdef HAVE_BLUESTUFF_AXI
-interface AXI_BRAM;
-   interface AXI4_Slave#(6, 64, 512, 0, 0, 0, 0, 0) portA;
-   interface AXI4_Slave#(6, 64, 512, 0, 0, 0, 0, 0) portB;
-endinterface
-`else
 interface AXI_BRAM;
    interface AXI4_Slave_IFC#(6, 64, 512, 0) portA;
    interface AXI4_Slave_IFC#(6, 64, 512, 0) portB;
 endinterface
-`endif
 
 (* synthesize *)
 module mkAXI_BRAM(AXI_BRAM);
-`ifdef HAVE_BLUESTUFF_AXI
-   AXI4_Slave_Xactor#(6, 64, 512, 0, 0, 0, 0, 0) bram_slave_xactor_portA <- mkAXI4_Slave_Xactor();
-   AXI4_Slave_Xactor#(6, 64, 512, 0, 0, 0, 0, 0) bram_slave_xactor_portB <- mkAXI4_Slave_Xactor();
-`else
    AXI4_Slave_Xactor_IFC#(6, 64, 512, 0) bram_slave_xactor_portA <- mkAXI4_Slave_Xactor();
    AXI4_Slave_Xactor_IFC#(6, 64, 512, 0) bram_slave_xactor_portB <- mkAXI4_Slave_Xactor();
-`endif
 
    Reg#(Bit#(2)) rg_verbosity <- mkReg(0);
 

--- a/hw/src_BSV/Boot_RAM.bsv
+++ b/hw/src_BSV/Boot_RAM.bsv
@@ -28,8 +28,8 @@ import Semi_FIFOF :: *;
 // ================================================================
 // Project imports
 
-import AXI4_Types  :: *;
-import Fabric_Defs :: *;
+import AWS_AXI4_Types  :: *;
+import AWS_Fabric_Defs :: *;
 
 // ================================================================
 // Interface

--- a/hw/src_BSV/UART_Model.bsv
+++ b/hw/src_BSV/UART_Model.bsv
@@ -47,12 +47,8 @@ import Semi_FIFOF :: *;
 // ================================================================
 // Project imports
 
-`ifdef HAVE_BLUESTUFF_AXI
-import Bluespec_AXI4_Types  :: *;
-`else
-import AXI4_Types  :: *;
-`endif
-import Fabric_Defs :: *;
+import AWS_AXI4_Types  :: *;
+import AWS_Fabric_Defs :: *;
 
 // ================================================================
 // UART registers and their address offsets


### PR DESCRIPTION
This means the GFE Flute's internal fabric's ID fields can remain as 4-bit, and we extend them at the boundary between the core and the AWS interconnect.

This is how it logically should be, as the two are independent, but having this separation will also make it easier to support CHERI Flute without needing lots of ifdefs everywhere to special-case it, instead limiting the BlueStuff AXI ifdefs to just AWS_AXI4_Connection.bsv.