### PR TITLE
Fix PCIS DMA loadelf for unaligned sections

### DIFF
--- a/src/helpers/memcpy.c
+++ b/src/helpers/memcpy.c
@@ -1,13 +1,33 @@
-
 #include <stddef.h>
 #include <stdint.h>
 
-void copy_from_bank2(uint64_t *dest, const uint64_t *src, size_t count, uint32_t *done)
+typedef uint64_t BLOCK;
+
+/* Not a general memcpy; must call with dest % sizeof(BLOCK) == src % sizeof(BLOCK) */
+void copy_from_bank2(char *dest, const char *src, size_t len, volatile size_t *done)
 {
-    for (size_t i = 0; i < count; ++i) {
+    char *end;
+    /* Copy leading bytes */
+    size_t leading = (sizeof(BLOCK) - ((size_t)src % sizeof(BLOCK))) % sizeof(BLOCK);
+    if (leading > len) {
+	leading = len;
+    }
+    for (end = dest + leading; dest != end;) {
 	*dest++ = *src++;
     }
-    *done = count;
+    /* Copy blocks */
+    size_t blocks = (len - leading) / sizeof(BLOCK);
+    for (end = dest + blocks * sizeof(BLOCK); dest != end;) {
+	*(BLOCK *)dest = *(const BLOCK *)src;
+	dest += sizeof(BLOCK);
+	src += sizeof(BLOCK);
+    }
+    /* Copy trailing bytes */
+    size_t trailing = (len - leading) % sizeof(BLOCK);
+    for (end = dest + trailing; dest != end;) {
+	*dest++ = *src++;
+    }
+    *done = len;
     while (1)
 	;
 }


### PR DESCRIPTION
We cannot assume that ELF files have all their loaded sections aligned
to 8 byte boundaries. This fixes the PCIS_DMA_Memory implementation to
make no assumptions about the alignment of its inputs, doing an AXI INCR
style of loading where we pad the first chunk as necessary to realign it
but don't actually write those bytes lest they clobber something we've
already written.

The prevalent use of uint32_t * for buffers elsewhere is still dodgy,
and many things will break if we ever try and do unaligned (or
sub-4-byte) accesses, but this is not new, and PCIS_DMA_Memory is at
least safe other than for its non-DMA fallback path. So far all the ELF
files needed to be loaded have 4-byte-aligned sections, either due to
their own alignment requirements, or due to the layout the linker chose.