### PR TITLE
Use separate 100 MHz clock for the core and up SoC clock to 250 MHz

### DIFF
--- a/hw/src_AWS_P2/Makefile
+++ b/hw/src_AWS_P2/Makefile
@@ -7,7 +7,7 @@ FLUTE_DIR ?= ../Flute
 ############################################################
 
 S2H_INTERFACES = AWSP2_Request:AWSP2.request
-H2S_INTERFACES = AWSP2:AWSP2_Response
+H2S_INTERFACES = AWSP2:AWSP2_Response:host.derivedClock,host.derivedReset
 MEM_READ_INTERFACES = lAWSP2.readClients
 MEM_WRITE_INTERFACES = lAWSP2.writeClients
 
@@ -40,6 +40,16 @@ CONNECTALFLAGS += -D AWSF1_CL_DEBUG_BRIDGE
 
 CONNECTALFLAGS += -D AWSF1_DDR_A
 CONNECTALFLAGS += -D AWSF1_DMA_PCIS
+
+CONNECTALFLAGS += --awsflags="-strategy TIMING"
+
+CONNECTALFLAGS += --awsflags="-clock_recipe_a A1"
+CONNECTALFLAGS += --mainclockperiod=4
+CONNECTALFLAGS += --pcieclockperiod=4
+CONNECTALFLAGS += --awsflags="-clock_recipe_b B5"
+CONNECTALFLAGS += --derivedclockperiod=10
+CONNECTALFLAGS += -D AWSF1_DERIVED_CLOCK=clk_extra_b1
+CONNECTALFLAGS += -D IMPORT_HOST_CLOCKS
 
 ############################################################
 ## copied from src_SSITH_P2 Makefile

--- a/hw/src_AWS_P2_CHERI/Makefile
+++ b/hw/src_AWS_P2_CHERI/Makefile
@@ -7,7 +7,7 @@ FLUTE_DIR ?= ../Flute_CHERI
 ############################################################
 
 S2H_INTERFACES = AWSP2_Request:AWSP2.request
-H2S_INTERFACES = AWSP2:AWSP2_Response
+H2S_INTERFACES = AWSP2:AWSP2_Response:host.derivedClock,host.derivedReset
 MEM_READ_INTERFACES = lAWSP2.readClients
 MEM_WRITE_INTERFACES = lAWSP2.writeClients
 
@@ -40,6 +40,16 @@ CONNECTALFLAGS += -D AWSF1_CL_DEBUG_BRIDGE
 
 CONNECTALFLAGS += -D AWSF1_DDR_A
 CONNECTALFLAGS += -D AWSF1_DMA_PCIS
+
+CONNECTALFLAGS += --awsflags="-strategy TIMING"
+
+CONNECTALFLAGS += --awsflags="-clock_recipe_a A1"
+CONNECTALFLAGS += --mainclockperiod=4
+CONNECTALFLAGS += --pcieclockperiod=4
+CONNECTALFLAGS += --awsflags="-clock_recipe_b B5"
+CONNECTALFLAGS += --derivedclockperiod=10
+CONNECTALFLAGS += -D AWSF1_DERIVED_CLOCK=clk_extra_b1
+CONNECTALFLAGS += -D IMPORT_HOST_CLOCKS
 
 ############################################################
 ## copied from src_SSITH_P2 Makefile

--- a/hw/src_AWS_P2_MIT/Makefile
+++ b/hw/src_AWS_P2_MIT/Makefile
@@ -50,6 +50,16 @@ CONNECTALFLAGS += -D AWSF1_CL_DEBUG_BRIDGE
 CONNECTALFLAGS += -D AWSF1_DDR_A
 CONNECTALFLAGS += -D AWSF1_DMA_PCIS
 
+CONNECTALFLAGS += --awsflags="-strategy TIMING"
+
+CONNECTALFLAGS += --awsflags="-clock_recipe_a A1"
+CONNECTALFLAGS += --mainclockperiod=4
+CONNECTALFLAGS += --pcieclockperiod=4
+CONNECTALFLAGS += --awsflags="-clock_recipe_b B5"
+CONNECTALFLAGS += --derivedclockperiod=10
+CONNECTALFLAGS += -D AWSF1_DERIVED_CLOCK=clk_extra_b1
+CONNECTALFLAGS += -D IMPORT_HOST_CLOCKS
+
 ############################################################
 ## copied from src_SSITH_P2 Makefile
 ############################################################

--- a/hw/src_AWS_P2_chisel/Makefile
+++ b/hw/src_AWS_P2_chisel/Makefile
@@ -41,6 +41,16 @@ CONNECTALFLAGS += -D AWSF1_CL_DEBUG_BRIDGE
 CONNECTALFLAGS += -D AWSF1_DDR_A
 CONNECTALFLAGS += -D AWSF1_DMA_PCIS
 
+CONNECTALFLAGS += --awsflags="-strategy TIMING"
+
+CONNECTALFLAGS += --awsflags="-clock_recipe_a A1"
+CONNECTALFLAGS += --mainclockperiod=4
+CONNECTALFLAGS += --pcieclockperiod=4
+CONNECTALFLAGS += --awsflags="-clock_recipe_b B5"
+CONNECTALFLAGS += --derivedclockperiod=10
+CONNECTALFLAGS += -D AWSF1_DERIVED_CLOCK=clk_extra_b1
+CONNECTALFLAGS += -D IMPORT_HOST_CLOCKS
+
 ############################################################
 ## copied from src_SSITH_P2 Makefile
 ############################################################

--- a/hw/src_BSV/AWS_AXI4_Crossing.bsv
+++ b/hw/src_BSV/AWS_AXI4_Crossing.bsv
@@ -1,0 +1,115 @@
+package AWS_AXI4_Crossing;
+
+// ================================================================
+// Bluespec library imports
+
+import Clocks :: *;
+
+// ================================================================
+// Project imports
+
+import AWS_AXI4_Types :: *;
+import GetPut_Aux     :: *;
+import Semi_FIFOF     :: *;
+
+// ================================================================
+// A Crossing has a master-side and a slave-side, but no reset
+
+interface AXI4_Crossing_IFC #(numeric type wd_id,
+			      numeric type wd_addr,
+			      numeric type wd_data,
+			      numeric type wd_user);
+   interface AXI4_Slave_IFC  #(wd_id, wd_addr, wd_data, wd_user) from_master;
+   interface AXI4_Master_IFC #(wd_id, wd_addr, wd_data, wd_user) to_slave;
+endinterface
+
+// ----------------------------------------------------------------
+
+module mkAXI4_Crossing #(Clock master_clock,
+			 Reset master_reset,
+			 Clock slave_clock,
+			 Reset slave_reset)
+		       (AXI4_Crossing_IFC #(wd_id, wd_addr, wd_data, wd_user));
+   AXI4_Slave_Xactor_IFC  #(wd_id, wd_addr, wd_data, wd_user) xactor_from_master <- mkAXI4_Slave_Xactor  (clocked_by master_clock, reset_by master_reset);
+   AXI4_Master_Xactor_IFC #(wd_id, wd_addr, wd_data, wd_user) xactor_to_slave    <- mkAXI4_Master_Xactor (clocked_by  slave_clock, reset_by  slave_reset);
+
+   SyncFIFOIfc #(AXI4_Wr_Addr #(wd_id, wd_addr, wd_user)) f_wr_addr <- mkSyncFIFO (4, master_clock, master_reset,  slave_clock);
+   SyncFIFOIfc #(AXI4_Wr_Data #(wd_data, wd_user))        f_wr_data <- mkSyncFIFO (4, master_clock, master_reset,  slave_clock);
+   SyncFIFOIfc #(AXI4_Wr_Resp #(wd_id, wd_user))          f_wr_resp <- mkSyncFIFO (4,  slave_clock,  slave_reset, master_clock);
+
+   SyncFIFOIfc #(AXI4_Rd_Addr #(wd_id, wd_addr, wd_user)) f_rd_addr <- mkSyncFIFO (4, master_clock, master_reset,  slave_clock);
+   SyncFIFOIfc #(AXI4_Rd_Data #(wd_id, wd_data, wd_user)) f_rd_data <- mkSyncFIFO (4,  slave_clock,  slave_reset, master_clock);
+
+   rule rl_master_wr_addr;
+      let wra <- pop_o (xactor_from_master.o_wr_addr);
+      f_wr_addr.enq (wra);
+   endrule
+
+   rule rl_master_wr_data;
+      let wrd <- pop_o (xactor_from_master.o_wr_data);
+      f_wr_data.enq (wrd);
+   endrule
+
+   rule rl_master_wr_resp;
+      let wrr <- pop (f_wr_resp);
+      xactor_from_master.i_wr_resp.enq (wrr);
+   endrule
+
+   rule rl_master_rd_addr;
+      let rda <- pop_o (xactor_from_master.o_rd_addr);
+      f_rd_addr.enq (rda);
+   endrule
+
+   rule rl_master_rd_data;
+      let rdr <- pop (f_rd_data);
+      xactor_from_master.i_rd_data.enq (rdr);
+   endrule
+
+   rule rl_slave_wr_addr;
+      let wra <- pop (f_wr_addr);
+      xactor_to_slave.i_wr_addr.enq (wra);
+   endrule
+
+   rule rl_slave_wr_data;
+      let wrd <- pop (f_wr_data);
+      xactor_to_slave.i_wr_data.enq (wrd);
+   endrule
+
+   rule rl_slave_wr_resp;
+      let wrr <- pop_o (xactor_to_slave.o_wr_resp);
+      f_wr_resp.enq (wrr);
+   endrule
+
+   rule rl_slave_rd_addr;
+      let rda <- pop (f_rd_addr);
+      xactor_to_slave.i_rd_addr.enq (rda);
+   endrule
+
+   rule rl_slave_rd_data;
+      let rdr <- pop_o (xactor_to_slave.o_rd_data);
+      f_rd_data.enq (rdr);
+   endrule
+
+   interface from_master = xactor_from_master.axi_side;
+   interface to_slave    = xactor_to_slave   .axi_side;
+endmodule
+
+module mkAXI4_CrossingFromCC #(Clock slave_clock, Reset slave_reset)
+			     (AXI4_Crossing_IFC #(wd_id, wd_addr, wd_data, wd_user));
+   let master_clock <- exposeCurrentClock;
+   let master_reset <- exposeCurrentReset;
+   let crossing <- mkAXI4_Crossing (master_clock, master_reset, slave_clock, slave_reset);
+
+   return crossing;
+endmodule
+
+module mkAXI4_CrossingToCC #(Clock master_clock, Reset master_reset)
+			   (AXI4_Crossing_IFC #(wd_id, wd_addr, wd_data, wd_user));
+   let slave_clock <- exposeCurrentClock;
+   let slave_reset <- exposeCurrentReset;
+   let crossing <- mkAXI4_Crossing (master_clock, master_reset, slave_clock, slave_reset);
+
+   return crossing;
+endmodule
+
+endpackage : AWS_AXI4_Crossing

--- a/src/dts/devicetree-cheri.dts
+++ b/src/dts/devicetree-cheri.dts
@@ -12,7 +12,7 @@
 	cpus {
 		#address-cells = <1>;
 		#size-cells = <0>;
-		timebase-frequency = <125000000>;
+		timebase-frequency = <100000000>;
 		CPU0: cpu@0 {
 			device_type = "cpu";
 			reg = <0>;
@@ -20,7 +20,7 @@
 			compatible = "riscv";
 			riscv,isa = "rv64imafdc";
 			mmu-type = "riscv,sv39";
-			clock-frequency = <125000000>;
+			clock-frequency = <100000000>;
 			CPU0_intc: interrupt-controller {
 				#interrupt-cells = <1>;
 				interrupt-controller;
@@ -69,7 +69,7 @@
 			compatible = "ns16550a";
 			interrupts-extended = <&plic 1>;
 			reg = <0x62300000 0x1000>;
-			clock-frequency = <125000000>;
+			clock-frequency = <250000000>;
 			reg-shift = <2>;
 		};
 	};

--- a/src/dts/devicetree.dts
+++ b/src/dts/devicetree.dts
@@ -12,7 +12,7 @@
 	cpus {
 		#address-cells = <1>;
 		#size-cells = <0>;
-		timebase-frequency = <125000000>;
+		timebase-frequency = <100000000>;
 		CPU0: cpu@0 {
 			device_type = "cpu";
 			reg = <0>;
@@ -20,7 +20,7 @@
 			compatible = "riscv";
 			riscv,isa = "rv64imafdc";
 			mmu-type = "riscv,sv39";
-			clock-frequency = <125000000>;
+			clock-frequency = <100000000>;
 			CPU0_intc: interrupt-controller {
 				#interrupt-cells = <1>;
 				interrupt-controller;
@@ -69,7 +69,7 @@
 			compatible = "ns16550a";
 			interrupts-extended = <&plic 1>;
 			reg = <0x62300000 0x1000>;
-			clock-frequency = <125000000>;
+			clock-frequency = <250000000>;
 			reg-shift = <2>;
 		};
 	};


### PR DESCRIPTION
The AWS clock recipes only give you three A clock recipes, none of which
are useful for us given we can't meet timing at 125 MHz. Patching the
AWS scripts to use a different clock frequency also doesn't help, as
there are crossings between clock_xtra within the shell and
clock_main_a0 with no synchronizer, so running clock_main_a0 at 97 MHz
(fpga-load-local-image lets you have either 97 or 109 MHz, and we can't
meet timing at the latter) causes either setup or hold violations on
that crossing. Presumably if fpga-load-local-image is given a different
frequency, the input to that clock is scaled (otherwise it wouldn't
work), but it is unclear whether clock_main_a0 will be scaled in a
compounding manner (causing us to run even slower than 97 MHz) or just
overwritten with a 97 MHz clock. This would all lead to a rather hacky
solution that does not inspire confidence.

Instead, we should do what the docs point towards, namely using a
separate clock group with a recipe that gives you a real 100 MHz clock
out of the box. For this, we choose B5's clock_extra_b1. We are then
also able to change the A group's recipe to A1, which clocks the SoC and
shell at 250 MHz and should help to alleviate the overheads of the CDCs.
Unfortunately, the lack of a mkGSyncFIFO interacts poorly with AXI, so
we need additional Xactors with their own mkGFIFOFs to give the
axi_side's unguarded interfaces, but hopefully the faster shell will
compensate sufficiently.

The lack of a pessimistic notEmpty signal on the enq side of a sync FIFO
is also frustrating, and gives rise to rg_dmi_reads_queued. If we don't
care about reporting that in dmi_status then it can however go away.