### PR TITLE
Feed VirtIO input in separate thread

### DIFF
--- a/src/fpga.cpp
+++ b/src/fpga.cpp
@@ -630,7 +630,6 @@ void AWSP2::process_io()
             }
         }
     }
-    virtio_devices.process_io();
 }
 
 void AWSP2::set_htif_base_addr(uint64_t baseaddr)

--- a/src/tinyemu/virtio.c
+++ b/src/tinyemu/virtio.c
@@ -1452,10 +1452,10 @@ static int virtio_entropy_recv_request(VIRTIODevice *s, int queue_idx,
             if (write_size - offset < block_size) {
                 block_size = write_size - offset;
             }
-            ret = getrandom(&s1->buf, block_size, 0);
+            ret = getrandom(s1->buf, block_size, 0);
             /* reads up to 256 bytes should always succeed */
             if (ret > 0) {
-                memcpy_to_queue(s, queue_idx, desc_idx, offset, &s1->buf, ret);
+                memcpy_to_queue(s, queue_idx, desc_idx, offset, s1->buf, ret);
                 offset += ret;
             } else {
                 abort();

--- a/src/virtiodevices.h
+++ b/src/virtiodevices.h
@@ -22,6 +22,10 @@ class VirtioDevices {
   IRQSignal *irq;
   int irq_num;
   const char *tun_ifname;
+  int stop_pipe[2];
+
+  void process_io();
+  static void *process_io_thread(void *opaque);
 
  public:
   VirtioDevices(int first_irq_num = 0, const char *tun_ifname = 0);
@@ -30,9 +34,9 @@ class VirtioDevices {
   uint8_t *phys_mem_get_ram_ptr(uint64_t paddr, BOOL is_rw);
   void set_dram_buffer(uint8_t *buf);
   void xdma_init(int c2h_fd, int h2c_fd);
-  void process_io();
   void add_virtio_block_device(std::string filename);
   void add_virtio_console_device();
   void start();
+  void stop();
 };
 


### PR DESCRIPTION
This means the ethernet (and console, though unused) input is decoupled from the main sleep loop, bringing latency down from seconds to milliseconds. I may later move the UART(/HTIF) input into its own thread too, but they're not so important.