### PR TITLE
Remove a couple of useless logging messages and hide the rest by default

### DIFF
--- a/src/connectal/dmaManager.c
+++ b/src/connectal/dmaManager.c
@@ -41,7 +41,7 @@ static pthread_mutex_t dma_mutex;
 pthread_once_t mutex_once = PTHREAD_ONCE_INIT;
 static void dmaManagerOnce(void)
 {
-  fprintf(stderr, "[%s:%d]\n", __FUNCTION__, __LINE__);
+  //fprintf(stderr, "[%s:%d]\n", __FUNCTION__, __LINE__);
   pthread_mutex_init(&dma_mutex, 0);
 }
 #endif

--- a/src/connectal/platformMemory.cpp
+++ b/src/connectal/platformMemory.cpp
@@ -117,7 +117,7 @@ void platformInitOnce(void)
     long req_freq = (long)(1e9 / MainClockPeriod);
     long freq = 0;
     setClockFrequency(0, req_freq, &freq);
-    fprintf(stderr, "Requested FCLK[0]=%ld actually %ld\n", req_freq, freq);
+    //fprintf(stderr, "Requested FCLK[0]=%ld actually %ld\n", req_freq, freq);
 #endif
 }
 DmaManager *platformInit(void)

--- a/src/connectal/portal.c
+++ b/src/connectal/portal.c
@@ -206,7 +206,7 @@ static void initPortalHardwareOnce(void)
 #ifndef SIMULATION
         int status;
         waitpid(pid, &status, 0);
-	fprintf(stderr, "subprocess pid %d completed status=%x %d\n", pid, status, WEXITSTATUS(status));
+	//fprintf(stderr, "subprocess pid %d completed status=%x %d\n", pid, status, WEXITSTATUS(status));
 #ifndef BOARD_de5
 	if (WEXITSTATUS(status) != 0)
 	    exit(-1);

--- a/src/loadelf.cpp
+++ b/src/loadelf.cpp
@@ -43,14 +43,14 @@ uint64_t loadElf(AWSP2 *fpga, const char *elf_filename, size_t max_mem_size)
 
     // Is this a 32b or 64 ELF?
     if (gelf_getclass(e) == ELFCLASS32) {
-        fprintf(stdout, "loadElf: %s is a 32-bit ELF file\n", elf_filename);
+        debugLog("loadElf: %s is a 32-bit ELF file\n", elf_filename);
         //bitwidth = 32;
     }
     else if (gelf_getclass(e) == ELFCLASS64) {
-        fprintf(stdout, "loadElf: %s is a 64-bit ELF file\n", elf_filename);
+        debugLog("loadElf: %s is a 64-bit ELF file\n", elf_filename);
         //bitwidth = 64;
         Elf64_Ehdr *ehdr64 = elf64_getehdr(e);
-        fprintf(stderr, "loadElf: entry point %08lx\n", ehdr64->e_entry);
+        debugLog("loadElf: entry point %08lx\n", ehdr64->e_entry);
         entry = ehdr64->e_entry;
     }
 
@@ -74,7 +74,7 @@ uint64_t loadElf(AWSP2 *fpga, const char *elf_filename, size_t max_mem_size)
     uint64_t base_pa = 0x80000000;
     for (int cnt = 0; cnt < ehdr.e_phnum; ++cnt) {
         gelf_getphdr(e, cnt, &phdr);
-        fprintf(stderr, "phdr %d type %x flags %x va %08lx pa %08lx\n", cnt, phdr.p_type, phdr.p_flags, phdr.p_vaddr, phdr.p_paddr);
+        debugLog("phdr %d type %x flags %x va %08lx pa %08lx\n", cnt, phdr.p_type, phdr.p_flags, phdr.p_vaddr, phdr.p_paddr);
         // phdr 0 type 1 flags 7 va ffffffc000000000 pa c0200000
         // phdr 1 type 2 flags 6 va ffffffc001b2c038 pa c1d2c038
         // phdr 2 type 6474e551 flags 6 va 00000000 pa 00000000
@@ -95,7 +95,7 @@ uint64_t loadElf(AWSP2 *fpga, const char *elf_filename, size_t max_mem_size)
         gelf_getshdr(scn, & shdr);
 
         char *sec_name = elf_strptr(e, shstrndx, shdr.sh_name);
-        fprintf(stdout, "Section %-16s: ", sec_name);
+        debugLog("Section %-16s: ", sec_name);
 
         // If we find a code/data section, load it into the model
         if (   ((shdr.sh_type == SHT_PROGBITS)
@@ -112,7 +112,6 @@ uint64_t loadElf(AWSP2 *fpga, const char *elf_filename, size_t max_mem_size)
             // n_initialized += data->d_size;
             uint32_t section_base_addr = shdr.sh_addr - base_va + base_pa;
             size_t max_addr = (section_base_addr + data->d_size - 1);    // shdr.sh_size + 4;
-            fprintf(stderr, "section_base_addr %08x max_addr %08lx\n", section_base_addr, max_addr);
 
             if (strcmp(sec_name, ".htif") == 0) {
                 fpga->set_htif_base_addr(section_base_addr);
@@ -134,7 +133,7 @@ uint64_t loadElf(AWSP2 *fpga, const char *elf_filename, size_t max_mem_size)
                 }
             }
 
-            fprintf (stdout, "addr %16x to addr %16lx; size 0x%8lx (= %0ld) bytes\n",
+            debugLog("addr %16x to addr %16lx; size 0x%8lx (= %0ld) bytes\n",
                      section_base_addr, section_base_addr + data->d_size, data->d_size, data->d_size);
 
         }
@@ -159,10 +158,10 @@ uint64_t loadElf(AWSP2 *fpga, const char *elf_filename, size_t max_mem_size)
 
             }
 
-            fprintf(stdout, "Parsed\n");
+            debugLog("Parsed\n");
         }
         else {
-            fprintf(stdout, "Ignored\n");
+            debugLog("Ignored\n");
         }
     }
 

--- a/src/tinyemu/virtio.c
+++ b/src/tinyemu/virtio.c
@@ -310,8 +310,6 @@ static void virtio_init(VIRTIODevice *s, VIRTIOBusDef *bus,
         /* MMIO case */
         s->mem_map = bus->mem_map;
         s->irq = bus->irq;
-        fprintf(stderr, "virtio_init device_id %d addr %08lx config_space_size %x virtio_page_size %x\n",
-                device_id, bus->addr, config_space_size, VIRTIO_PAGE_SIZE);
         s->mem_range = cpu_register_device(s->mem_map, bus->addr, VIRTIO_PAGE_SIZE,
                                            s, virtio_mmio_read, virtio_mmio_write,
                                            DEVIO_SIZE8 | DEVIO_SIZE16 | DEVIO_SIZE32);
@@ -1302,19 +1300,15 @@ static void virtio_net_write_packet(EthernetDevice *es, const uint8_t *buf, int 
 
 static void virtio_net_set_carrier(EthernetDevice *es, BOOL carrier_state)
 {
-    fprintf(stderr, "%s: carrier_state %d\n", __FUNCTION__, carrier_state);
-#if 0
     VIRTIODevice *s1 = es->device_opaque;
     VIRTIONetDevice *s = (VIRTIONetDevice *)s1;
     int cur_carrier_state;
 
-    //    printf("virtio_net_set_carrier: %d\n", carrier_state);
     cur_carrier_state = s->common.config_space[6] & 1;
     if (cur_carrier_state != carrier_state) {
         s->common.config_space[6] = (carrier_state << 0);
         virtio_config_change_notify(s1);
     }
-#endif
 }
 
 VIRTIODevice *virtio_net_init(VIRTIOBusDef *bus, EthernetDevice *es)
@@ -1358,14 +1352,12 @@ static int virtio_console_recv_request(VIRTIODevice *s, int queue_idx,
     CharacterDevice *cs = s1->cs;
     uint8_t *buf;
 
-    fprintf(stderr, "%s: queue_idx %d\n", __FUNCTION__, queue_idx);
     if (queue_idx == 1) {
         /* send to console */
         buf = malloc(read_size+1);
         memset(buf, 0, read_size+1);
         memcpy_from_queue(s, buf, queue_idx, desc_idx, 0, read_size);
         cs->write_data(cs->opaque, buf, read_size);
-        fprintf(stderr, "%s: buf %s\n", __FUNCTION__, buf);
         free(buf);
         virtio_consume_desc(s, queue_idx, desc_idx, 0);
     }
@@ -1377,7 +1369,6 @@ BOOL virtio_console_can_write_data(VIRTIODevice *s)
     QueueState *qs = &s->queue[0];
 
     if (!qs->ready) {
-      //fprintf(stderr, "%s: !qs->ready\n", __FUNCTION__);
         return FALSE;
     }
     return qs->last_avail_idx != qs->avail_idx;

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -8,6 +8,7 @@
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <unistd.h>
+#include <stdarg.h>
 
 #include "util.h"
 
@@ -34,9 +35,28 @@ int copyFile(char *buffer, const char *filename, size_t buffer_size)
             break;
         memcpy(buffer + bytes_copied, readbuf, bytes_read);
         bytes_copied += bytes_read;
-        fprintf(stderr, "Copied %d bytes %ld bytes total readsize %ld\n", bytes_read, bytes_copied, readsize);
+        debugLog("Copied %d bytes %ld bytes total readsize %ld\n", bytes_read, bytes_copied, readsize);
     } while (bytes_copied < buffer_size);
     close(fd);
-    fprintf(stderr, "Read %ld bytes from %s\n", bytes_copied, filename);
+    debugLog("Read %ld bytes from %s\n", bytes_copied, filename);
     return bytes_copied;
+}
+
+static int debug = 0;
+
+void setEnableDebugLog(int enable)
+{
+    debug = enable;
+}
+
+int debugLog(const char * __restrict format, ...)
+{
+    if (!debug)
+        return 0;
+
+    va_list ap;
+    va_start(ap, format);
+    int ret = vfprintf(stderr, format, ap);
+    va_end(ap);
+    return ret;
 }

--- a/src/util.h
+++ b/src/util.h
@@ -1,3 +1,5 @@
 
 int copyFile(char *buffer, const char *filename, size_t buffer_size);
 
+void setEnableDebugLog(int enable);
+int debugLog(const char * __restrict format, ...) __attribute__((__format__ (__printf__, 1, 2)));

--- a/src/virtiodevices.cpp
+++ b/src/virtiodevices.cpp
@@ -15,6 +15,7 @@ extern "C" {
 
 #include "fpga.h"
 #include "virtiodevices.h"
+#include "util.h"
 
 static int debug = 0;
 
@@ -71,13 +72,13 @@ VirtioDevices::VirtioDevices(int first_irq_num, const char *tun_ifname)
     virtio_bus->irq = &irq[irq_num++];
     ethernet_device = tun_ifname ? tun_open(tun_ifname) : slirp_open();
     virtio_net = virtio_net_init(virtio_bus, ethernet_device);
-    fprintf(stderr, "ethernet device %p virtio net device %p at addr %08lx\n", ethernet_device, virtio_net, virtio_bus->addr);
+    debugLog("ethernet device %p virtio net device %p at addr %08lx\n", ethernet_device, virtio_net, virtio_bus->addr);
 
     // set up an entropy device
     virtio_bus->addr += 0x1000;
     virtio_bus->irq = &irq[irq_num++];
     virtio_entropy = virtio_entropy_init(virtio_bus);
-    fprintf(stderr, "virtio entropy device %p at addr %08lx\n", virtio_entropy, virtio_bus->addr);
+    debugLog("virtio entropy device %p at addr %08lx\n", virtio_entropy, virtio_bus->addr);
 }
 
 VirtioDevices::~VirtioDevices() {
@@ -89,9 +90,9 @@ void VirtioDevices::add_virtio_block_device(std::string filename)
     virtio_bus->addr += 0x1000;
     virtio_bus->irq = &irq[irq_num++];
     block_device = block_device_init(filename.c_str(), BF_MODE_RW);
-    fprintf(stderr, "block device %s (%p)\n", filename.c_str(), block_device);
+    debugLog("block device %s (%p)\n", filename.c_str(), block_device);
     virtio_block = virtio_block_init(virtio_bus, block_device);
-    fprintf(stderr, "virtio block device %p at addr %08lx\n", virtio_block, virtio_bus->addr);
+    debugLog("virtio block device %p at addr %08lx\n", virtio_block, virtio_bus->addr);
 
 }
 


### PR DESCRIPTION
This adds a new -L flag that turns them back on. These messages are only
useful for debugging, and hiding them by default provides a better user
experience rather than being bombarded with an assortment of debug
messages.