### PR TITLE
More timing changes

### DIFF
--- a/hw/scripts/Include_Common.mk
+++ b/hw/scripts/Include_Common.mk
@@ -1,3 +1,5 @@
+SCRIPTSDIR := $(dir $(abspath $(lastword $(MAKEFILE_LIST))))
+
 CONNECTALDIR ?= ../connectal
 
 ############################################################
@@ -54,6 +56,11 @@ prebuild:: $(CONNECTALDIR)/out/awsf1/ila_connectal_1/ila_connectal_1.xci
 
 $(CONNECTALDIR)/out/awsf1/ila_connectal_1/ila_connectal_1.xci:
 	cd awsf1; vivado -mode batch -source $(CONNECTALDIR)/scripts/connectal-synth-ila.tcl
+
+prebuild:: awsf1/strategy_OVERRIDES.tcl
+
+awsf1/strategy_OVERRIDES.tcl: $(SCRIPTSDIR)/strategy_OVERRIDES.tcl
+	cp $^ $@
 endif
 
 include $(CONNECTALDIR)/Makefile.connectal

--- a/hw/scripts/Include_Common.mk
+++ b/hw/scripts/Include_Common.mk
@@ -1,0 +1,59 @@
+CONNECTALDIR ?= ../connectal
+
+############################################################
+## Connectal topgen configuration
+############################################################
+
+S2H_INTERFACES = AWSP2_Request:AWSP2.request
+H2S_INTERFACES = AWSP2:AWSP2_Response:host.derivedClock,host.derivedReset
+MEM_READ_INTERFACES = lAWSP2.readClients
+MEM_WRITE_INTERFACES = lAWSP2.writeClients
+
+ifeq ($(BOARD),awsf1)
+PIN_TYPE=AWSP2_Pin_IFC
+PIN_TYPE_INCLUDE=AWSP2_IFC
+AUTOTOP = --interface pins:AWSP2.pins
+endif
+
+BSVFILES = ../src_BSV/AWSP2_IFC.bsv
+
+############################################################
+## the software source code and compiler flags
+############################################################
+
+CPPFILES = ../src_Software/loadelf.cpp ../src_Software/testawsp2.cpp
+CONNECTALFLAGS += -lelf
+
+############################################################
+## Configuring connectal platform hardware
+############################################################
+
+CONNECTALFLAGS += -D SIM_DMA_READ_LATENCY=1
+CONNECTALFLAGS += -D SIM_DMA_WRITE_LATENCY=1
+
+CONNECTALFLAGS += -D BYTE_ENABLES_MEM_DATA
+CONNECTALFLAGS += -D DataBusWidth=512
+CONNECTALFLAGS += -D AWSF1_CL_DEBUG_BRIDGE
+
+CONNECTALFLAGS += -D AWSF1_DDR_A
+CONNECTALFLAGS += -D AWSF1_DMA_PCIS
+
+CONNECTALFLAGS += --awsflags="-strategy TIMING"
+
+CONNECTALFLAGS += --awsflags="-clock_recipe_a A1"
+CONNECTALFLAGS += --mainclockperiod=4
+CONNECTALFLAGS += --pcieclockperiod=4
+CONNECTALFLAGS += --awsflags="-clock_recipe_b B5"
+CONNECTALFLAGS += --derivedclockperiod=10
+CONNECTALFLAGS += -D AWSF1_DERIVED_CLOCK=clk_extra_b1
+CONNECTALFLAGS += -D IMPORT_HOST_CLOCKS
+
+ifeq ($(BOARD),awsf1)
+
+prebuild:: $(CONNECTALDIR)/out/awsf1/ila_connectal_1/ila_connectal_1.xci
+
+$(CONNECTALDIR)/out/awsf1/ila_connectal_1/ila_connectal_1.xci:
+	cd awsf1; vivado -mode batch -source $(CONNECTALDIR)/scripts/connectal-synth-ila.tcl
+endif
+
+include $(CONNECTALDIR)/Makefile.connectal

--- a/hw/scripts/strategy_OVERRIDES.tcl
+++ b/hw/scripts/strategy_OVERRIDES.tcl
@@ -1,0 +1,6 @@
+set synth_options   "-no_lc -shreg_min_size 10 -control_set_opt_threshold 16 $synth_uram_option"
+set synth_directive "AlternateRoutability"
+
+set place_directive "AltSpreadLogic_medium"
+
+set route_directive "AggressiveExplore"

--- a/hw/src_AWS_P2/Makefile
+++ b/hw/src_AWS_P2/Makefile
@@ -1,55 +1,4 @@
-CONNECTALDIR ?= ../connectal
-
 FLUTE_DIR ?= ../Flute
-
-############################################################
-## Connectal topgen configuration
-############################################################
-
-S2H_INTERFACES = AWSP2_Request:AWSP2.request
-H2S_INTERFACES = AWSP2:AWSP2_Response:host.derivedClock,host.derivedReset
-MEM_READ_INTERFACES = lAWSP2.readClients
-MEM_WRITE_INTERFACES = lAWSP2.writeClients
-
-ifeq ($(BOARD),awsf1)
-PIN_TYPE=AWSP2_Pin_IFC
-PIN_TYPE_INCLUDE=AWSP2_IFC
-AUTOTOP = --interface pins:AWSP2.pins
-endif
-
-BSVFILES = ../src_BSV/AWSP2_IFC.bsv
-
-############################################################
-## the software source code and compiler flags
-############################################################
-
-CPPFILES = ../src_Software/loadelf.cpp ../src_Software/testawsp2.cpp
-CONNECTALFLAGS += -lelf
-
-
-############################################################
-## Configuring connectal platform hardware
-############################################################
-
-CONNECTALFLAGS += -D SIM_DMA_READ_LATENCY=1
-CONNECTALFLAGS += -D SIM_DMA_WRITE_LATENCY=1
-
-CONNECTALFLAGS += -D BYTE_ENABLES_MEM_DATA
-CONNECTALFLAGS += -D DataBusWidth=512
-CONNECTALFLAGS += -D AWSF1_CL_DEBUG_BRIDGE
-
-CONNECTALFLAGS += -D AWSF1_DDR_A
-CONNECTALFLAGS += -D AWSF1_DMA_PCIS
-
-CONNECTALFLAGS += --awsflags="-strategy TIMING"
-
-CONNECTALFLAGS += --awsflags="-clock_recipe_a A1"
-CONNECTALFLAGS += --mainclockperiod=4
-CONNECTALFLAGS += --pcieclockperiod=4
-CONNECTALFLAGS += --awsflags="-clock_recipe_b B5"
-CONNECTALFLAGS += --derivedclockperiod=10
-CONNECTALFLAGS += -D AWSF1_DERIVED_CLOCK=clk_extra_b1
-CONNECTALFLAGS += -D IMPORT_HOST_CLOCKS
 
 ############################################################
 ## copied from src_SSITH_P2 Makefile
@@ -106,12 +55,4 @@ CONNECTALFLAGS += $(shell test -d $(BLUESPECDIR)/Libraries/AMBA_TLM3/Axi && echo
 CONNECTALFLAGS += $(shell test -d $(BLUESPECDIR)/Libraries/AMBA_TLM3/Axi4 && echo --bsvpath=$(BLUESPECDIR)/Libraries/AMBA_TLM3/Axi4)
 CONNECTALFLAGS += $(shell test -d $(BLUESPECDIR)/Libraries/AMBA_TLM3/TLM3 && echo --bsvpath=$(BLUESPECDIR)/Libraries/AMBA_TLM3/TLM3)
 
-ifeq ($(BOARD),awsf1)
-
-prebuild:: $(CONNECTALDIR)/out/awsf1/ila_connectal_1/ila_connectal_1.xci
-
-$(CONNECTALDIR)/out/awsf1/ila_connectal_1/ila_connectal_1.xci:
-	cd awsf1; vivado -mode batch -source $(CONNECTALDIR)/scripts/connectal-synth-ila.tcl
-endif
-
-include $(CONNECTALDIR)/Makefile.connectal
+include ../scripts/Include_Common.mk

--- a/hw/src_AWS_P2_CHERI/Makefile
+++ b/hw/src_AWS_P2_CHERI/Makefile
@@ -1,55 +1,4 @@
-CONNECTALDIR ?= ../connectal
-
 FLUTE_DIR ?= ../Flute_CHERI
-
-############################################################
-## Connectal topgen configuration
-############################################################
-
-S2H_INTERFACES = AWSP2_Request:AWSP2.request
-H2S_INTERFACES = AWSP2:AWSP2_Response:host.derivedClock,host.derivedReset
-MEM_READ_INTERFACES = lAWSP2.readClients
-MEM_WRITE_INTERFACES = lAWSP2.writeClients
-
-ifeq ($(BOARD),awsf1)
-PIN_TYPE=AWSP2_Pin_IFC
-PIN_TYPE_INCLUDE=AWSP2_IFC
-AUTOTOP = --interface pins:AWSP2.pins
-endif
-
-BSVFILES = ../src_BSV/AWSP2_IFC.bsv
-
-############################################################
-## the software source code and compiler flags
-############################################################
-
-CPPFILES = ../src_Software/loadelf.cpp ../src_Software/testawsp2.cpp
-CONNECTALFLAGS += -lelf
-
-
-############################################################
-## Configuring connectal platform hardware
-############################################################
-
-CONNECTALFLAGS += -D SIM_DMA_READ_LATENCY=1
-CONNECTALFLAGS += -D SIM_DMA_WRITE_LATENCY=1
-
-CONNECTALFLAGS += -D BYTE_ENABLES_MEM_DATA
-CONNECTALFLAGS += -D DataBusWidth=512
-CONNECTALFLAGS += -D AWSF1_CL_DEBUG_BRIDGE
-
-CONNECTALFLAGS += -D AWSF1_DDR_A
-CONNECTALFLAGS += -D AWSF1_DMA_PCIS
-
-CONNECTALFLAGS += --awsflags="-strategy TIMING"
-
-CONNECTALFLAGS += --awsflags="-clock_recipe_a A1"
-CONNECTALFLAGS += --mainclockperiod=4
-CONNECTALFLAGS += --pcieclockperiod=4
-CONNECTALFLAGS += --awsflags="-clock_recipe_b B5"
-CONNECTALFLAGS += --derivedclockperiod=10
-CONNECTALFLAGS += -D AWSF1_DERIVED_CLOCK=clk_extra_b1
-CONNECTALFLAGS += -D IMPORT_HOST_CLOCKS
 
 ############################################################
 ## copied from src_SSITH_P2 Makefile
@@ -125,12 +74,4 @@ prebuild::
 	$(MAKE) -C $(FLUTE_DIR)/src_SSITH_P2 src_BSV/TagTableStructure.bsv
 	cp -uv $(FLUTE_DIR)/src_SSITH_P2/src_BSV/TagTableStructure.bsv .
 
-ifeq ($(BOARD),awsf1)
-
-prebuild:: $(CONNECTALDIR)/out/awsf1/ila_connectal_1/ila_connectal_1.xci
-
-$(CONNECTALDIR)/out/awsf1/ila_connectal_1/ila_connectal_1.xci:
-	cd awsf1; vivado -mode batch -source $(CONNECTALDIR)/scripts/connectal-synth-ila.tcl
-endif
-
-include $(CONNECTALDIR)/Makefile.connectal
+include ../scripts/Include_Common.mk

--- a/hw/src_AWS_P2_MIT/Makefile
+++ b/hw/src_AWS_P2_MIT/Makefile
@@ -1,31 +1,4 @@
-CONNECTALDIR?= ../connectal
-
 FLUTE_DIR?=../FluteEnclavesTagging
-
-############################################################
-## Connectal topgen configuration 
-############################################################
-
-S2H_INTERFACES = AWSP2_Request:AWSP2.request
-H2S_INTERFACES = AWSP2:AWSP2_Response
-MEM_READ_INTERFACES = lAWSP2.readClients
-MEM_WRITE_INTERFACES = lAWSP2.writeClients
-
-ifeq ($(BOARD),awsf1)
-PIN_TYPE=AWSP2_Pin_IFC
-PIN_TYPE_INCLUDE=AWSP2_IFC
-AUTOTOP = --interface pins:AWSP2.pins
-endif
-
-BSVFILES = ../src_BSV/AWSP2_IFC.bsv
-
-############################################################
-## the software source code and compiler flags
-############################################################
-
-CPPFILES = ../src_Software/loadelf.cpp ../src_Software/testawsp2.cpp
-CONNECTALFLAGS += -lelf
-
 
 ############################################################
 ## Configuring MIT SSITH P2
@@ -35,30 +8,6 @@ CONNECTALFLAGS += -D PUBLIC_ACCESS_POLICY
 
 CONNECTALFLAGS += --bsvpath=$(FLUTE_DIR)/src_Core/Tagged
 CONNECTALFLAGS += --bsvpath=$(FLUTE_DIR)/src_Core/TaggingPolicies
-
-############################################################
-## Configuring connectal platform hardware
-############################################################
-
-CONNECTALFLAGS += -D SIM_DMA_READ_LATENCY=1
-CONNECTALFLAGS += -D SIM_DMA_WRITE_LATENCY=1
-
-CONNECTALFLAGS += -D BYTE_ENABLES_MEM_DATA
-CONNECTALFLAGS += -D DataBusWidth=512
-CONNECTALFLAGS += -D AWSF1_CL_DEBUG_BRIDGE
-
-CONNECTALFLAGS += -D AWSF1_DDR_A
-CONNECTALFLAGS += -D AWSF1_DMA_PCIS
-
-CONNECTALFLAGS += --awsflags="-strategy TIMING"
-
-CONNECTALFLAGS += --awsflags="-clock_recipe_a A1"
-CONNECTALFLAGS += --mainclockperiod=4
-CONNECTALFLAGS += --pcieclockperiod=4
-CONNECTALFLAGS += --awsflags="-clock_recipe_b B5"
-CONNECTALFLAGS += --derivedclockperiod=10
-CONNECTALFLAGS += -D AWSF1_DERIVED_CLOCK=clk_extra_b1
-CONNECTALFLAGS += -D IMPORT_HOST_CLOCKS
 
 ############################################################
 ## copied from src_SSITH_P2 Makefile
@@ -108,12 +57,4 @@ CONNECTALFLAGS += $(shell test -d $(BLUESPECDIR)/Libraries/AMBA_TLM3/Axi && echo
 CONNECTALFLAGS += $(shell test -d $(BLUESPECDIR)/Libraries/AMBA_TLM3/Axi4 && echo --bsvpath=$(BLUESPECDIR)/Libraries/AMBA_TLM3/Axi4)
 CONNECTALFLAGS += $(shell test -d $(BLUESPECDIR)/Libraries/AMBA_TLM3/TLM3 && echo --bsvpath=$(BLUESPECDIR)/Libraries/AMBA_TLM3/TLM3)
 
-ifeq ($(BOARD),awsf1)
-
-prebuild:: $(CONNECTALDIR)/out/awsf1/ila_connectal_1/ila_connectal_1.xci
-
-$(CONNECTALDIR)/out/awsf1/ila_connectal_1/ila_connectal_1.xci:
-	cd awsf1; vivado -mode batch -source $(CONNECTALDIR)/scripts/connectal-synth-ila.tcl
-endif
-
-include $(CONNECTALDIR)/Makefile.connectal
+include ../scripts/Include_Common.mk

--- a/hw/src_AWS_P2_chisel/Makefile
+++ b/hw/src_AWS_P2_chisel/Makefile
@@ -1,55 +1,4 @@
-CONNECTALDIR ?= ../connectal
-
 FLUTE_DIR ?= ../Flute
-
-############################################################
-## Connectal topgen configuration
-############################################################
-
-S2H_INTERFACES = AWSP2_Request:AWSP2.request
-H2S_INTERFACES = AWSP2:AWSP2_Response
-MEM_READ_INTERFACES = lAWSP2.readClients
-MEM_WRITE_INTERFACES = lAWSP2.writeClients
-
-ifeq ($(BOARD),awsf1)
-PIN_TYPE=AWSP2_Pin_IFC
-PIN_TYPE_INCLUDE=AWSP2_IFC
-AUTOTOP = --interface pins:AWSP2.pins
-endif
-
-BSVFILES = ../src_BSV/AWSP2_IFC.bsv
-
-############################################################
-## the software source code and compiler flags
-############################################################
-
-CPPFILES = ../src_Software/loadelf.cpp ../src_Software/testawsp2.cpp
-CONNECTALFLAGS += -lelf
-
-
-############################################################
-## Configuring connectal platform hardware
-############################################################
-
-CONNECTALFLAGS += -D SIM_DMA_READ_LATENCY=1
-CONNECTALFLAGS += -D SIM_DMA_WRITE_LATENCY=1
-
-CONNECTALFLAGS += -D BYTE_ENABLES_MEM_DATA
-CONNECTALFLAGS += -D DataBusWidth=512
-CONNECTALFLAGS += -D AWSF1_CL_DEBUG_BRIDGE
-
-CONNECTALFLAGS += -D AWSF1_DDR_A
-CONNECTALFLAGS += -D AWSF1_DMA_PCIS
-
-CONNECTALFLAGS += --awsflags="-strategy TIMING"
-
-CONNECTALFLAGS += --awsflags="-clock_recipe_a A1"
-CONNECTALFLAGS += --mainclockperiod=4
-CONNECTALFLAGS += --pcieclockperiod=4
-CONNECTALFLAGS += --awsflags="-clock_recipe_b B5"
-CONNECTALFLAGS += --derivedclockperiod=10
-CONNECTALFLAGS += -D AWSF1_DERIVED_CLOCK=clk_extra_b1
-CONNECTALFLAGS += -D IMPORT_HOST_CLOCKS
 
 ############################################################
 ## copied from src_SSITH_P2 Makefile
@@ -105,12 +54,4 @@ CONNECTALFLAGS += $(shell test -d $(BLUESPECDIR)/Libraries/AMBA_TLM3/Axi && echo
 CONNECTALFLAGS += $(shell test -d $(BLUESPECDIR)/Libraries/AMBA_TLM3/Axi4 && echo --bsvpath=$(BLUESPECDIR)/Libraries/AMBA_TLM3/Axi4)
 CONNECTALFLAGS += $(shell test -d $(BLUESPECDIR)/Libraries/AMBA_TLM3/TLM3 && echo --bsvpath=$(BLUESPECDIR)/Libraries/AMBA_TLM3/TLM3)
 
-ifeq ($(BOARD),awsf1)
-
-prebuild:: $(CONNECTALDIR)/out/awsf1/ila_connectal_1/ila_connectal_1.xci
-
-$(CONNECTALDIR)/out/awsf1/ila_connectal_1/ila_connectal_1.xci:
-	cd awsf1; vivado -mode batch -source $(CONNECTALDIR)/scripts/connectal-synth-ila.tcl
-endif
-
-include $(CONNECTALDIR)/Makefile.connectal
+include ../scripts/Include_Common.mk


### PR DESCRIPTION
Finally managed to get both src_AWS_P2 and src_AWS_P2_CHERI to pass timing, though it's not the easiest task for Vivado. Also includes a simplification of the DMI FIFOs, and a much-needed extraction of the common logic from the 4 different Makefiles governing the Connectal configuration (which, incidentally, revealed I managed to miss adding the derived clock/reset signals to H2S_INTERFACES for the MIT and chisel cores, precisely the kind of thing this unification avoids).