### PR TITLE
Proper ELF loader and support multiple ELF files

### DIFF
--- a/src/loadelf.cpp
+++ b/src/loadelf.cpp
@@ -17,7 +17,7 @@ int debug_pcis_write = 0;
 __attribute__((aligned(4096)))
 static uint8_t zeroes[4096];
 
-uint64_t loadElf(AWSP2 *fpga, const char *elf_filename, size_t max_mem_size)
+uint64_t loadElf(AWSP2 *fpga, const char *elf_filename, size_t max_mem_size, bool set_htif)
 {
     // Verify the elf library version
     if (elf_version(EV_CURRENT) == EV_NONE) {
@@ -162,14 +162,16 @@ uint64_t loadElf(AWSP2 *fpga, const char *elf_filename, size_t max_mem_size)
 
     elf_end(e);
 
-    if (htif_paddr) {
-        fpga->set_htif_base_addr(htif_paddr);
-    }
-    if (tohost_paddr) {
-        fpga->set_tohost_addr(tohost_paddr);
-    }
-    if (fromhost_paddr) {
-        fpga->set_fromhost_addr(fromhost_paddr);
+    if (set_htif) {
+        if (htif_paddr) {
+            fpga->set_htif_base_addr(htif_paddr);
+        }
+        if (tohost_paddr) {
+            fpga->set_tohost_addr(tohost_paddr);
+        }
+        if (fromhost_paddr) {
+            fpga->set_fromhost_addr(fromhost_paddr);
+        }
     }
 
     return entry_paddr;

--- a/src/loadelf.cpp
+++ b/src/loadelf.cpp
@@ -14,6 +14,9 @@
 
 int debug_pcis_write = 0;
 
+__attribute__((aligned(4096)))
+static uint8_t zeroes[4096];
+
 uint64_t loadElf(AWSP2 *fpga, const char *elf_filename, size_t max_mem_size)
 {
     // Verify the elf library version
@@ -24,7 +27,7 @@ uint64_t loadElf(AWSP2 *fpga, const char *elf_filename, size_t max_mem_size)
 
     int fd = open(elf_filename, O_RDONLY);
     Elf *e = elf_begin(fd, ELF_C_READ, NULL);
-    uint64_t entry = 0;
+    uint64_t entry_vaddr = 0;
 
     // Verify that the file is an ELF file
     if (elf_kind(e) != ELF_K_ELF) {
@@ -51,7 +54,7 @@ uint64_t loadElf(AWSP2 *fpga, const char *elf_filename, size_t max_mem_size)
         //bitwidth = 64;
         Elf64_Ehdr *ehdr64 = elf64_getehdr(e);
         debugLog("loadElf: entry point %08lx\n", ehdr64->e_entry);
-        entry = ehdr64->e_entry;
+        entry_vaddr = ehdr64->e_entry;
     }
 
     // Verify we are dealing with a RISC-V ELF
@@ -69,77 +72,25 @@ uint64_t loadElf(AWSP2 *fpga, const char *elf_filename, size_t max_mem_size)
         exit(1);
     }
 
-    Elf64_Phdr phdr;
-    uint64_t base_va = 0x80000000;
-    uint64_t base_pa = 0x80000000;
-    for (int cnt = 0; cnt < ehdr.e_phnum; ++cnt) {
-        gelf_getphdr(e, cnt, &phdr);
-        debugLog("phdr %d type %x flags %x va %08lx pa %08lx\n", cnt, phdr.p_type, phdr.p_flags, phdr.p_vaddr, phdr.p_paddr);
-        // phdr 0 type 1 flags 7 va ffffffc000000000 pa c0200000
-        // phdr 1 type 2 flags 6 va ffffffc001b2c038 pa c1d2c038
-        // phdr 2 type 6474e551 flags 6 va 00000000 pa 00000000
-        // phdr 3 type 4 flags 4 va ffffffc001aa5098 pa c1ca5098
 
-        if (phdr.p_type == PT_LOAD) {
-            base_va = phdr.p_vaddr;
-            base_pa = phdr.p_paddr;
-        }
-    }
-
+    uint64_t htif_vaddr = 0;
+    uint64_t tohost_vaddr = 0;
+    uint64_t fromhost_vaddr = 0;
     // Grab the string section index
     size_t shstrndx = ehdr.e_shstrndx;
     Elf_Scn  *scn   = 0;
     while ((scn = elf_nextscn(e,scn)) != NULL) {
         // get the header information for this section
         GElf_Shdr shdr;
-        gelf_getshdr(scn, & shdr);
+        gelf_getshdr(scn, &shdr);
 
         char *sec_name = elf_strptr(e, shstrndx, shdr.sh_name);
         debugLog("Section %-16s: ", sec_name);
-
-        // If we find a code/data section, load it into the model
-        if (   ((shdr.sh_type == SHT_PROGBITS)
-                || (shdr.sh_type == SHT_NOBITS)
-                || (shdr.sh_type == SHT_INIT_ARRAY)
-                || (shdr.sh_type == SHT_FINI_ARRAY))
-            && ((shdr.sh_flags & SHF_WRITE)
-                || (shdr.sh_flags & SHF_ALLOC)
-                || (shdr.sh_flags & SHF_EXECINSTR))) {
-
-            Elf_Data *data = 0;
-            data = elf_getdata (scn, data);
-
-            // n_initialized += data->d_size;
-            uint32_t section_base_addr = shdr.sh_addr - base_va + base_pa;
-            size_t max_addr = (section_base_addr + data->d_size - 1);    // shdr.sh_size + 4;
-
-            if (strcmp(sec_name, ".htif") == 0) {
-                fpga->set_htif_base_addr(section_base_addr);
-            } else if (strcmp(sec_name, ".tohost") == 0) {
-                fpga->set_tohost_addr(section_base_addr);
-            } else if (strcmp(sec_name, ".fromhost") == 0) {
-                fpga->set_fromhost_addr(section_base_addr);
-            } else {
-                if (data->d_size > max_mem_size) {
-                    fprintf(stdout, "INTERNAL ERROR: section size (0x%0lx) > buffer size (0x%0lx)\n",
-                            data->d_size, max_mem_size);
-                    fprintf(stdout, "    Please increase the #define in this program, recompile, and run again\n");
-                    fprintf(stdout, "    Abandoning this run\n");
-                    exit(1);
-                }
-
-                if (shdr.sh_type != SHT_NOBITS) {
-                    fpga->write(section_base_addr, (uint8_t *)data->d_buf, data->d_size);
-                }
-            }
-
-            debugLog("addr %16x to addr %16lx; size 0x%8lx (= %0ld) bytes\n",
-                     section_base_addr, section_base_addr + data->d_size, data->d_size, data->d_size);
-
-        }
+        debugLog("addr %16lx to addr %16lx; size 0x%8lx (= %0ld) bytes\n",
+                 shdr.sh_addr, shdr.sh_addr + shdr.sh_size, shdr.sh_size, shdr.sh_size);
 
         // If we find the symbol table, search for symbols of interest
-        else if (shdr.sh_type == SHT_SYMTAB) {
+        if (shdr.sh_type == SHT_SYMTAB) {
 
             // Get the section data
             Elf_Data *data = 0;
@@ -158,14 +109,68 @@ uint64_t loadElf(AWSP2 *fpga, const char *elf_filename, size_t max_mem_size)
 
             }
 
-            debugLog("Parsed\n");
+            continue;
         }
-        else {
-            debugLog("Ignored\n");
+
+        Elf_Data *data = 0;
+        data = elf_getdata (scn, data);
+
+        if (strcmp(sec_name, ".htif") == 0) {
+            htif_vaddr = shdr.sh_addr;
+        } else if (strcmp(sec_name, ".tohost") == 0) {
+            tohost_vaddr = shdr.sh_addr;
+        } else if (strcmp(sec_name, ".fromhost") == 0) {
+            fromhost_vaddr = shdr.sh_addr;
+        }
+    }
+
+    Elf64_Phdr phdr;
+    uint8_t *rawdata = (uint8_t *)elf_rawfile(e, NULL);
+    uint64_t entry_paddr = entry_vaddr;
+    uint64_t htif_paddr = htif_vaddr;
+    uint64_t tohost_paddr = tohost_vaddr;
+    uint64_t fromhost_paddr = fromhost_vaddr;
+    for (int cnt = 0; cnt < ehdr.e_phnum; ++cnt) {
+        gelf_getphdr(e, cnt, &phdr);
+        debugLog("phdr %d type %x flags %x va %08lx pa %08lx\n", cnt, phdr.p_type, phdr.p_flags, phdr.p_vaddr, phdr.p_paddr);
+
+        if (phdr.p_type != PT_LOAD) continue;
+
+        fpga->write(phdr.p_paddr, rawdata + phdr.p_offset, phdr.p_filesz);
+        size_t zero_paddr = phdr.p_paddr + phdr.p_filesz;
+        size_t zero_len = phdr.p_memsz - phdr.p_filesz;
+        while (zero_len > 0) {
+            size_t block_len = std::min(zero_len, sizeof(zeroes));
+            fpga->write(zero_paddr, zeroes, block_len);
+            zero_paddr += block_len;
+            zero_len -= block_len;
+        }
+
+        if (phdr.p_vaddr <= entry_vaddr && entry_vaddr < phdr.p_vaddr + phdr.p_memsz) {
+            entry_paddr = phdr.p_paddr + (entry_vaddr - phdr.p_vaddr);
+        }
+        if (phdr.p_vaddr <= htif_vaddr && htif_vaddr < phdr.p_vaddr + phdr.p_memsz) {
+            htif_paddr = phdr.p_paddr + (htif_vaddr - phdr.p_vaddr);
+        }
+        if (phdr.p_vaddr <= tohost_vaddr && tohost_vaddr < phdr.p_vaddr + phdr.p_memsz) {
+            tohost_paddr = phdr.p_paddr + (tohost_vaddr - phdr.p_vaddr);
+        }
+        if (phdr.p_vaddr <= fromhost_vaddr && fromhost_vaddr < phdr.p_vaddr + phdr.p_memsz) {
+            fromhost_paddr = phdr.p_paddr + (fromhost_vaddr - phdr.p_vaddr);
         }
     }
 
     elf_end(e);
 
-    return entry;
+    if (htif_paddr) {
+        fpga->set_htif_base_addr(htif_paddr);
+    }
+    if (tohost_paddr) {
+        fpga->set_tohost_addr(tohost_paddr);
+    }
+    if (fromhost_paddr) {
+        fpga->set_fromhost_addr(fromhost_paddr);
+    }
+
+    return entry_paddr;
 }

--- a/src/loadelf.h
+++ b/src/loadelf.h
@@ -2,4 +2,4 @@
 #include <stdint.h>
 
 class AWSP2;
-uint64_t loadElf(AWSP2 *fpga, const char *elf_filename, size_t max_mem_size);
+uint64_t loadElf(AWSP2 *fpga, const char *elf_filename, size_t max_mem_size, bool set_htif);


### PR DESCRIPTION
This turns loadElf into a proper ELF loader, i.e. using the program headers as intended (GDB's `load` command is the exception, and a bad design decision that should not be repeated).

This also allows multiple ELF files to be provided, with the intent being that you can provide separate BBL/OpenSBI and kernel ELF files, without having to embed the latter in the former (which is both a real nuisance and far too easy to forget to do), provided your kernel is linked with an LMA (physical base address) of 0xc0200000. This is how we normally boot, both on QEMU (using `-bios bbl` and `-kernel kernel`) and via netboot (using `boot 10.88.88.1 bbl kernel`) on the VCU118.