### PR TITLE
Add SiFive Test Finisher device

### DIFF
--- a/src/dts/devicetree-cheri.dts
+++ b/src/dts/devicetree-cheri.dts
@@ -94,4 +94,16 @@
 		interrupts-extended = <&plic 5>;
 		reg = <0x40003000 0x1000>;
 	};
+
+	sifive_test: sifive_test@50000000 {
+		reg = <0x50000000 0x1000>;
+		compatible = "sifive,test0", "syscon";
+	};
+
+	poweroff {
+		value = <0x5555>;
+		offset = <0x0>;
+		regmap = <&sifive_test>;
+		compatible = "syscon-poweroff";
+	};
 };

--- a/src/dts/devicetree.dts
+++ b/src/dts/devicetree.dts
@@ -94,4 +94,16 @@
 		interrupts-extended = <&plic 5>;
 		reg = <0x40003000 0x1000>;
 	};
+
+	sifive_test: sifive_test@50000000 {
+		reg = <0x50000000 0x1000>;
+		compatible = "sifive,test0", "syscon";
+	};
+
+	poweroff {
+		value = <0x5555>;
+		offset = <0x0>;
+		regmap = <&sifive_test>;
+		compatible = "syscon-poweroff";
+	};
 };

--- a/src/fpga.h
+++ b/src/fpga.h
@@ -128,6 +128,7 @@ class AWSP2 {
     bsvvector_Luint8_t_L64 pcis_rsp_data;
     uint64_t tohost_addr;
     uint64_t fromhost_addr;
+    uint64_t sifive_test_addr;
     uint64_t htif_enabled;
     uint64_t uart_enabled;
     int pcis_dma_fd;
@@ -135,6 +136,7 @@ class AWSP2 {
     size_t dram_mapping_size;
     int xdma_c2h_fd;
     int xdma_h2c_fd;
+    int exit_code;
 
     std::mutex client_mutex;
     std::mutex stdin_mutex;
@@ -188,8 +190,8 @@ public:
 
     VirtioDevices &get_virtio_devices() { return virtio_devices; }
     void start_io();
-    void stop_io();
-    void join_io();
+    void stop_io(int code);
+    int join_io();
 
     void set_htif_base_addr(uint64_t baseaddr);
     void set_tohost_addr(uint64_t addr);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -296,6 +296,5 @@ int main(int argc, char * const *argv)
     }
 #endif
 
-    fpga->join_io();
-    return 0;
+    return fpga->join_io();
 }


### PR DESCRIPTION
Unlike the HTIF, which requires modifying BBL's linker script to use an
I/O address, the SiFive Test Finisher has its address in the device tree
like a normal memory-mapped device, but otherwise its functionality is
very similar. BBL uses it as the primary means of powering off when
present, falling back on the HTIF (which doesn't work out of the box for
us) and then, finally, a WFI loop to spin.

Thus, provide an implementation of the SiFive Test Finisher so that BBL
is able to shut down completely. We only implement sifive,test0 and not
also sifive,test1; the latter adds an additional 0x7777 value for
resetting (which would not be much effort to refactor main.cpp to
support), but neither BBL nor OpenSBI provide an SBI call that lets you
reboot. Linux probably supports it if exposed via syscon-reboot, but
FreeBSD has no such driver (although it really should) and is wholly
reliant on SBI calls.

Whilst hooking this up, also make the HTIF riscv-tests device actually
exit and report the status.